### PR TITLE
Amélioration du système de token et de sa durée de vie

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 0
-:minor: 3
+:minor: 4
 :patch: 0
 :special: ''
 :metadata: ''

--- a/App/Components/Authentification/Controller.php
+++ b/App/Components/Authentification/Controller.php
@@ -46,19 +46,19 @@ final class Controller extends \App\Libraries\AController
                 'login' => $login,
                 'password' => $password,
             ]);
-            $utilisateurUpdated = $this->repository->regenerateToken($utilisateur);
-
-            $code = 200;
-            $data = [
-                'code' => $code,
-                'status' => 'success',
-                'message' => '',
-                'data' => $utilisateurUpdated->getToken(),
-            ];
-
-            return $response->withJson($data, $code);
         } catch (\UnexpectedValueException $e) {
             return $this->getResponseNotFound($response, 'No user matches these criteria');
         }
+        $utilisateurUpdated = $this->repository->regenerateToken($utilisateur);
+
+        $code = 200;
+        $data = [
+            'code' => $code,
+            'status' => 'success',
+            'message' => '',
+            'data' => $utilisateurUpdated->getToken(),
+        ];
+
+        return $response->withJson($data, $code);
     }
 }

--- a/App/Components/Utilisateur/Dao.php
+++ b/App/Components/Utilisateur/Dao.php
@@ -57,6 +57,10 @@ class Dao extends \App\Libraries\ADao
             $where[] = 'token = :token';
             $bind[':token'] = $parametres['token'];
         }
+        if (!empty($parametres['gt_date_last_access'])) {
+            $where[] = 'date_last_access >= :gt_date_last_access';
+            $bind[':gt_date_last_access'] = $parametres['gt_date_last_access'];
+        }
 
         return [
             'where' => !empty($where)

--- a/App/Components/Utilisateur/Dao.php
+++ b/App/Components/Utilisateur/Dao.php
@@ -53,6 +53,10 @@ class Dao extends \App\Libraries\ADao
             $where[] = 'u_passwd = :u_passwd';
             $bind[':u_passwd'] = $parametres['u_passwd'];
         }
+        if (!empty($parametres['token'])) {
+            $where[] = 'token = :token';
+            $bind[':token'] = $parametres['token'];
+        }
 
         return [
             'where' => !empty($where)
@@ -79,11 +83,12 @@ class Dao extends \App\Libraries\ADao
     public function put(array $data, $id)
     {
         $req = 'UPDATE ' . $this->getTableName() . '
-            SET token = :token
+            SET token = :token, date_last_access = :date_last_access
             WHERE u_login = :id';
         $res = $this->storageConnector->prepare($req);
         $res->execute([
             'token' => $data['token'],
+            'date_last_access' => $data['date_last_access'],
             'id' => $id,
         ]);
     }

--- a/App/Components/Utilisateur/Model.php
+++ b/App/Components/Utilisateur/Model.php
@@ -34,6 +34,11 @@ class Model extends \App\Libraries\AModel
         return $this->getFreshData('dateInscription');
     }
 
+    public function getDateLastAccess()
+    {
+        return $this->getFreshData('dateLastAccess');
+    }
+
     /**
      * @inheritDoc
      */
@@ -75,6 +80,11 @@ class Model extends \App\Libraries\AModel
         }
 
         $this->dataUpdated['token'] = $token;
+    }
+
+    public function updateLastAccess()
+    {
+        $this->dataUpdated['dateLastAccess'] = date('Y-m-d H:i:s', time() + 6000);
     }
 
     /**

--- a/App/Components/Utilisateur/Model.php
+++ b/App/Components/Utilisateur/Model.php
@@ -82,9 +82,9 @@ class Model extends \App\Libraries\AModel
         $this->dataUpdated['token'] = $token;
     }
 
-    public function updateLastAccess()
+    public function updateDateLastAccess()
     {
-        $this->dataUpdated['dateLastAccess'] = date('Y-m-d H:i:s');
+        $this->dataUpdated['dateLastAccess'] = date('Y-m-d H:i');
     }
 
     /**

--- a/App/Components/Utilisateur/Model.php
+++ b/App/Components/Utilisateur/Model.php
@@ -84,7 +84,7 @@ class Model extends \App\Libraries\AModel
 
     public function updateLastAccess()
     {
-        $this->dataUpdated['dateLastAccess'] = date('Y-m-d H:i:s', time() + 6000);
+        $this->dataUpdated['dateLastAccess'] = date('Y-m-d H:i:s');
     }
 
     /**

--- a/App/Components/Utilisateur/Model.php
+++ b/App/Components/Utilisateur/Model.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Components\Utilisateur;
 
+use App\Helpers\Formatter;
+
 /**
  * @inheritDoc
  *
@@ -82,9 +84,12 @@ class Model extends \App\Libraries\AModel
         $this->dataUpdated['token'] = $token;
     }
 
+    /**
+     * @since 0.3
+     */
     public function updateDateLastAccess()
     {
-        $this->dataUpdated['dateLastAccess'] = date('Y-m-d H:i');
+        $this->dataUpdated['dateLastAccess'] = Formatter::timeToSQLDatetime(time());
     }
 
     /**

--- a/App/Components/Utilisateur/Repository.php
+++ b/App/Components/Utilisateur/Repository.php
@@ -13,7 +13,7 @@ use App\Libraries\Application;
  * @since 0.2
  * @see \Tests\Units\App\Components\Utilisateur\Repository
  *
- * Ne devrait être contacté que par le Authentification\Controller
+ * Ne devrait être contacté que par le Authentification\Controller et \Middlewares\Identification
  * Ne devrait contacter que le Utilisateur\Model, Utilisateur\Dao
  */
 class Repository extends \App\Libraries\ARepository
@@ -137,6 +137,18 @@ class Repository extends \App\Libraries\ARepository
     }
 
     /**
+     * « Ping » la date de dernier accès de l'utilisateur
+     *
+     * @param Model $model Modèle utilisateur
+     */
+    public function updateDateLastAccess(Model $model)
+    {
+        $model->updateDateLastAccess();
+        $dataDao = $this->getModel2DataDao($model);
+        $this->dao->put($dataDao, $model->getId());
+    }
+
+    /**
      * Regénère le token de l'utilisateur pour une nouvelle session
      *
      * @param AModel $model Modèle utilisateur
@@ -146,13 +158,13 @@ class Repository extends \App\Libraries\ARepository
     public function regenerateToken(AModel $model)
     {
         $instanceToken = $this->application->getTokenInstance();
-        if ('' === $instanceToken) {
+        if (empty($instanceToken)) {
             throw new \RuntimeException('Instance token is not set');
         }
 
         try {
             $model->populateToken($this->buildToken($instanceToken));
-            $model->updateLastAccess();
+            $model->updateDateLastAccess();
             $dataDao = $this->getModel2DataDao($model);
             $this->dao->put($dataDao, $model->getId());
 

--- a/App/Components/Utilisateur/Repository.php
+++ b/App/Components/Utilisateur/Repository.php
@@ -23,6 +23,11 @@ class Repository extends \App\Libraries\ARepository
      */
     private $application;
 
+    /**
+     * Ajoute la bibliothèque d'accès aux données, pour la génération du token
+     *
+     * @param Application $application
+     */
     public function setApplication(Application $application)
     {
         if ($this->application instanceof Application) {
@@ -140,6 +145,8 @@ class Repository extends \App\Libraries\ARepository
      * « Ping » la date de dernier accès de l'utilisateur
      *
      * @param Model $model Modèle utilisateur
+     *
+     * @since 0.3
      */
     public function updateDateLastAccess(Model $model)
     {
@@ -154,6 +161,7 @@ class Repository extends \App\Libraries\ARepository
      * @param AModel $model Modèle utilisateur
      *
      * @return AModel Le modèle hydraté du nouveau token
+     * @throws \RuntimeException Si le token instance n'est pas posé
      */
     public function regenerateToken(AModel $model)
     {

--- a/App/Components/Utilisateur/Repository.php
+++ b/App/Components/Utilisateur/Repository.php
@@ -114,6 +114,9 @@ class Repository extends \App\Libraries\ARepository
         if (!empty($paramsConsumer['token'])) {
             $results['token'] = (string) $paramsConsumer['token'];
         }
+        if (!empty($paramsConsumer['gt_date_last_access'])) {
+            $results['gt_date_last_access'] = (string) $paramsConsumer['gt_date_last_access'];
+        }
         return $results;
     }
 

--- a/App/Helpers/Formatter.php
+++ b/App/Helpers/Formatter.php
@@ -59,4 +59,17 @@ class Formatter
 
         return $terme;
     }
+
+    /**
+     * Fourni la datetime au format SQL d'un timestamp donné
+     *
+     * @param int $timestamp
+     *
+     * @return string
+     * @since 0.3
+     */
+    public static function timeToSQLDatetime($timestamp)
+    {
+        return date('Y-m-d H:i', $timestamp);
+    }
 }

--- a/Middlewares.php
+++ b/Middlewares.php
@@ -51,7 +51,7 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
     }
 });
 
-/* Middleware 4 : sécurité via identification */
+/* Middleware 4 : sécurité via identification (+ « ping » last access) */
 $app->add(function (IRequest $request, IResponse $response, callable $next) {
     /**
     * TODO
@@ -65,6 +65,7 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
     if (in_array($ressourcePath, $reserved, true)) {
         return $next($request, $response);
     } elseif ($identification->isTokenOk()) {
+        // ping
         $this['currentUser'] = $identification->getUtilisateur();
         return $next($request, $response);
     } else {

--- a/Middlewares.php
+++ b/Middlewares.php
@@ -58,7 +58,7 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
         new \App\Components\Utilisateur\Dao($this['storageConnector'])
     );
     $identification = new \Middlewares\Identification($request, $repoUtilisateur);
-    $reserved = ['Authentification'];
+    $reserved = ['Authentification', 'HelloWorld'];
     $ressourcePath = $request->getAttribute('nomRessources');
     if (in_array($ressourcePath, $reserved, true)) {
         return $next($request, $response);

--- a/Middlewares.php
+++ b/Middlewares.php
@@ -53,9 +53,6 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
 
 /* Middleware 4 : sécurité via identification (+ « ping » last access) */
 $app->add(function (IRequest $request, IResponse $response, callable $next) {
-    /**
-    * TODO
-    */
     $repoUtilisateur = new \App\Components\Utilisateur\Repository(
         new \App\Components\Utilisateur\Dao($this['storageConnector'])
     );
@@ -65,8 +62,11 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
     if (in_array($ressourcePath, $reserved, true)) {
         return $next($request, $response);
     } elseif ($identification->isTokenOk()) {
-        // ping
-        $this['currentUser'] = $identification->getUtilisateur();
+        $utilisateur = $identification->getUtilisateur();
+        // Ping de last_access
+        $repoUtilisateur->updateDateLastAccess($utilisateur);
+
+        $this['currentUser'] = $utilisateur;
         return $next($request, $response);
     } else {
         return call_user_func(

--- a/Middlewares.php
+++ b/Middlewares.php
@@ -59,11 +59,13 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
     $repoUtilisateur = new \App\Components\Utilisateur\Repository(
         new \App\Components\Utilisateur\Dao($this['storageConnector'])
     );
+    $identification = new \Middlewares\Identification($request, $repoUtilisateur);
     $reserved = ['Authentification'];
     $ressourcePath = $request->getAttribute('nomRessources');
     if (in_array($ressourcePath, $reserved, true)) {
         return $next($request, $response);
-    } elseif ((new \Middlewares\Identification($request))->isTokenApiOk()) {
+    } elseif ($identification->isTokenOk()) {
+        $this['currentUser'] = $identification->getUtilisateur();
         return $next($request, $response);
     } else {
         return call_user_func(

--- a/Middlewares.php
+++ b/Middlewares.php
@@ -36,10 +36,11 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
 /* Middleware 5 : sécurité via droits d'accès sur la ressource */
 $app->add(function (IRequest $request, IResponse $response, callable $next) {
     /**
-    * TODO
-    *
-    * qu'est ce que ça veut dire qu'une ressource est accessible, et où le mettre ? dépend du rôle ?
-    */
+     * TODO
+     *
+     * qu'est ce que ça veut dire qu'une ressource est accessible, et où le mettre ? dépend du rôle ?
+     * On peut désormais s'appuyer sur le DIC : $this['currentUser']
+     */
     if (true) {
         return $next($request, $response);
     } else {

--- a/Middlewares/Identification.php
+++ b/Middlewares/Identification.php
@@ -1,6 +1,7 @@
 <?php
 namespace Middlewares;
 
+use App\Libraries\AModel;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 
 /**
@@ -11,13 +12,23 @@ use Psr\Http\Message\ServerRequestInterface as IRequest;
 final class Identification
 {
     /**
-     * @var IRequest
+     * @var \App\Libraries\AModel
      */
-    private $request;
+    private $utilisateur;
 
-    public function __construct(IRequest $request)
+    public function __construct(IRequest $request, \App\Libraries\ARepository $repository)
     {
-        $this->request = $request;
+        $token = $request->getHeaderLine('Token');
+        if ('' === $token) {
+            return;
+        }
+        try {
+            $this->utilisateur = $repository->find([
+                'token' => $token,
+            ]);
+        } catch (\UnexpectedValueException $e) {
+            return;
+        }
     }
 
     /**
@@ -25,8 +36,13 @@ final class Identification
      *
      * @return bool
      */
-    public function isTokenApiOk()
+    public function isTokenOk()
     {
-        return true;
+        return $this->getUtilisateur() instanceof AModel;
+    }
+
+    public function getUtilisateur()
+    {
+        return $this->utilisateur;
     }
 }

--- a/Middlewares/Identification.php
+++ b/Middlewares/Identification.php
@@ -19,7 +19,7 @@ final class Identification
     public function __construct(IRequest $request, \App\Libraries\ARepository $repository)
     {
         $token = $request->getHeaderLine('Token');
-        if ('' === $token) {
+        if (empty($token)) {
             return;
         }
         try {
@@ -39,7 +39,7 @@ final class Identification
      */
     private function getDateLastAccessAuthorized()
     {
-        return date('Y-m-d H:i', time() - 15 * 60);
+        return date('Y-m-d H:i', time() - 5 * 60);
     }
 
     /**

--- a/Middlewares/Identification.php
+++ b/Middlewares/Identification.php
@@ -3,6 +3,7 @@ namespace Middlewares;
 
 use App\Libraries\AModel;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
+use App\Helpers\Formatter;
 
 /**
  * Identification d'un utilisateur via la transmission du token
@@ -11,6 +12,10 @@ use Psr\Http\Message\ServerRequestInterface as IRequest;
  */
 final class Identification
 {
+    /**
+     * @var int Durée de validité du token fourni, en secondes
+     */
+    const DUREE_SESSION = 5*60;
     /**
      * @var \App\Libraries\AModel
      */
@@ -39,7 +44,7 @@ final class Identification
      */
     private function getDateLastAccessAuthorized()
     {
-        return date('Y-m-d H:i', time() - 5 * 60);
+        return Formatter::timeToSQLDatetime(time() - static::DUREE_SESSION);
     }
 
     /**
@@ -52,6 +57,10 @@ final class Identification
         return $this->getUtilisateur() instanceof AModel;
     }
 
+    /**
+     * Retourne l'utilisateur courant
+     * @since 0.3
+     */
     public function getUtilisateur()
     {
         return $this->utilisateur;

--- a/Middlewares/Identification.php
+++ b/Middlewares/Identification.php
@@ -25,10 +25,21 @@ final class Identification
         try {
             $this->utilisateur = $repository->find([
                 'token' => $token,
+                'gt_date_last_access' => $this->getDateLastAccessAuthorized()
             ]);
         } catch (\UnexpectedValueException $e) {
             return;
         }
+    }
+
+    /**
+     * Retourne la date limite de dernier accès pour être considéré en ligne
+     *
+     * @return string
+     */
+    private function getDateLastAccessAuthorized()
+    {
+        return date('Y-m-d H:i', time() - 15 * 60);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ C'est préférable pour l'isolation des systèmes (donc la sécurité), en plus 
 Les échanges se font en JSON et nous suivons les codes HTTP standards.
 
 # Requête
-En tant qu'architecture REST, les échanges sont *sans-état*, ce qui signifie que le serveur ne stocke pas d'informations pour se *souvenir* d'un client et n'induit rien. Cela implique que le client doit fournir toutes les informations nécessaires à la réalisation d'une action, passant tout d'abord par une *connexion*, puis la transmission à chaque requête du *token* reçu suite à cette connexion.
+En tant qu'architecture REST, les échanges sont *sans-état*, ce qui signifie que le serveur ne stocke pas d'information pour se *souvenir* d'un client et n'induit rien. Cela implique que le client doit fournir toutes les informations nécessaires à la réalisation d'une action, passant tout d'abord par une *connexion*, puis la transmission à chaque requête du *token* reçu suite à cette connexion.
 
 Les headers basiques, à transmettre pour toute requête, sont :
 ```
@@ -82,7 +82,7 @@ Suivant les règles de l'architecture REST, les routes disponibles à ce jour so
 * `GET /plannings/{id}/creneaux/{id}`
 * `DELETE /plannings/{id}/creneaux/{id}`
 
-## Versions
+# Versions
 
 L'API suit `semver`, ce qui signifie qu'une route ne sera enlevée ou que ses spécifications ne seront changées que si la version passe `vM.0.0`.
 Attention : pour le moment, le logiciel n'est pas encore en `v1.m.p`, donc ces [cassages de compatibilité](https://github.com/Prytoegrian/check-break#what-is-a-compatibility-break-) peuvent arriver à tout moment.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ L'API Libertempo doit être installée comme un domaine à part, autrement dit :
 - api.libertempo.mon-entreprise.tld
 
 Et non pas comme un sous-répertoire de votre domaine existant :
-- mon-entreprise.tld/libertempo
+- mon-entreprise.tld/libertempo/api
+- libertempo.mon-entreprise.tld/api
 
 C'est préférable pour l'isolation des systèmes (donc la sécurité), en plus d'être plus simple à gérer côté applicatif (plus de certitudes, donc moins de bugs).
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,85 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c9248e3a815347209c8e56d2291f0da7)](https://www.codacy.com/app/Libertempo/libertempo-api?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Libertempo/libertempo-api&amp;utm_campaign=Badge_Grade)
 [![Build Status](https://travis-ci.org/Libertempo/libertempo-api.svg?branch=master)](https://travis-ci.org/Libertempo/libertempo-api)
 
-API de l'application web Libertempo
+API Libertempo
+---
+
+# Initialisation
+L'API Libertempo doit être installée comme un domaine à part, autrement dit :
+- api.libertempo.tld
+- api.libertempo.mon-entreprise.tld
+
+Et non pas comme un sous-répertoire de votre domaine existant :
+- mon-entreprise.tld/libertempo
+
+C'est préférable pour l'isolation des systèmes (donc la sécurité), en plus d'être plus simple à gérer côté applicatif (plus de certitudes, donc moins de bugs).
+
+Les échanges se font en JSON et nous suivons les codes HTTP standards.
+
+# Requête
+En tant qu'architecture REST, les échanges sont *sans-état*, ce qui signifie que le serveur ne stocke pas d'informations pour se *souvenir* d'un client et n'induit rien. Cela implique que le client doit fournir toutes les informations nécessaires à la réalisation d'une action, passant tout d'abord par une *connexion*, puis la transmission à chaque requête du *token* reçu suite à cette connexion.
+
+Les headers basiques, à transmettre pour toute requête, sont :
+```
+Content-Type: application/json
+Accept: application/json
+```
+
+## Première requête
+Afin de vérifier que l'installation de l'API s'est bien déroulée, nous avons mis en place une route sans authentification :
+```
+GET /hello_world
+```
+
+## Authentification
+L'authentification s'appuie sur la méthode [Basic Access](https://en.wikipedia.org/wiki/Basic_access_authentication) :
+```
+GET /authentification
+Authorization: Basic {base64(login:mot_de_passe)}
+```
+
+Si l'utilisateur existe et a le droit de se connecter, l'API enverra le token d'identification, dont la durée de validité est de 5min (repoussée à chaque échange).
+
+## Échanges authentifiés
+Une fois connecté, tous les échanges devront avoir le header :
+```
+Token: {token}
+```
+
+## Requêtes avec données
+Lors d'un ordre avec données (POST | PUT), le corps de la requête doit ressembler à :
+```JSON
+{
+    "propriété1": "valeur1",
+    "propriétéN": "valeurN"
+}
+```
+
+# Réponse
+
+Les réponses de l'API se font sous la spécification jsend. Autrement dit :
+```JSON
+{
+    "code": "codeHTTP",
+    "status": "typeDeReponse",
+    "message": "messageCorrespondantAuCode",
+    "data": "donnéesDeRéponse"
+}
+```
+
+# Routes disponibles
+Suivant les règles de l'architecture REST, les routes disponibles à ce jour sont :
+* `GET /plannings`
+* `POST /plannings`
+* `GET /plannings/{id}`
+* `PUT /plannings/{id}`
+* `DELETE /plannings/{id}`
+* `GET /plannings/{id}/creneaux`
+* `POST /plannings/{id}/creneaux`
+* `GET /plannings/{id}/creneaux/{id}`
+* `DELETE /plannings/{id}/creneaux/{id}`
+
+## Versions
+
+L'API suit `semver`, ce qui signifie qu'une route ne sera enlevée ou que ses spécifications ne seront changées que si la version passe `vM.0.0`.
+Attention : pour le moment, le logiciel n'est pas encore en `v1.m.p`, donc ces [cassages de compatibilité](https://github.com/Prytoegrian/check-break#what-is-a-compatibility-break-) peuvent arriver à tout moment.

--- a/Tests/Units/App/Components/Utilisateur/Dao.php
+++ b/Tests/Units/App/Components/Utilisateur/Dao.php
@@ -72,6 +72,7 @@ final class Dao extends \Tests\Units\App\Libraries\ADao
 
         $put = $dao->put([
             'token' => 'token',
+            'date_last_access' => 'date_last_access',
         ], 'Aladdin');
 
         $this->variable($put)->isNull();

--- a/Tests/Units/App/Components/Utilisateur/Model.php
+++ b/Tests/Units/App/Components/Utilisateur/Model.php
@@ -71,4 +71,15 @@ final class Model extends \Tests\Units\App\Libraries\AModel
 
         $this->string($model->getToken())->isIdenticalTo($token);
     }
+
+    public function testUpdateDateLastAccess()
+    {
+        $model = new _Model(['id' => 3, 'dateLastAccess' => "0"]);
+
+        $this->string($model->getDateLastAccess())->isIdenticalTo("0");
+
+        $model->updateDateLastAccess();
+
+        $this->string($model->getDateLastAccess())->isIdenticalTo(date('Y-m-d H:i'));
+    }
 }

--- a/Tests/Units/App/Components/Utilisateur/Model.php
+++ b/Tests/Units/App/Components/Utilisateur/Model.php
@@ -36,6 +36,16 @@ final class Model extends \Tests\Units\App\Libraries\AModel
     }
 
     /**
+     * @since 0.3
+     */
+    public function testGetLogin()
+    {
+        $model = new _Model(['token' => 'token', 'login' => 'login']);
+
+        $this->variable($model->getLogin())->isNull();
+    }
+
+    /**
      * @inheritDoc
      */
     public function testReset()

--- a/Tests/Units/App/Components/Utilisateur/Repository.php
+++ b/Tests/Units/App/Components/Utilisateur/Repository.php
@@ -117,6 +117,7 @@ final class Repository extends \Atoum
                 'u_heure_solde' => 983,
                 'date_inscription' => 2,
                 'token' => '',
+                'date_last_access' => 3,
             ],
             [
                 'id' => 'Sinbad',
@@ -136,6 +137,7 @@ final class Repository extends \Atoum
                 'u_heure_solde' => 1218,
                 'date_inscription' => 2,
                 'token' => '',
+                'date_last_access' => 134,
             ],
         ];
         $repository = new _Repository($this->dao);
@@ -181,6 +183,7 @@ final class Repository extends \Atoum
             'u_heure_solde' => 983,
             'date_inscription' => 2,
             'token' => '',
+            'date_last_access' => 98,
         ]];
         $repository = new _Repository($this->dao);
 

--- a/Tests/Units/App/Components/Utilisateur/Repository.php
+++ b/Tests/Units/App/Components/Utilisateur/Repository.php
@@ -212,6 +212,18 @@ final class Repository extends \Atoum
         $this->variable((new _Repository($this->dao))->putOne([], $this->model))->isNull();
     }
 
+    public function testUpdateDateLastAccess()
+    {
+        $repo = new _Repository($this->dao);
+        $this->model->getMockController()->getToken = 'Tartuffe';
+
+        $repo->updateDateLastAccess($this->model);
+
+        $this->mock($this->model)->call('updateDateLastAccess')->once();
+        $this->mock($this->dao)->call('put')->once();
+
+    }
+
     /**
      * Teste la méthode generateToken avec un token d'instance vide
      */

--- a/Tests/Units/App/Helpers/Formatter.php
+++ b/Tests/Units/App/Helpers/Formatter.php
@@ -91,4 +91,16 @@ final class Formatter extends \Atoum
 
         $this->string($singular)->isIdenticalTo($term);
     }
+
+    /**
+     * Teste la mise au format de datetime sql
+     */
+    public function testTimeToSQLDatetime()
+    {
+        $time0 = 0;
+        $timeFixed = 1303819038;
+
+        $this->string(_Formatter::timeToSQLDatetime($time0))->isIdenticalTo('1970-01-01 00:00');
+        $this->string(_Formatter::timeToSQLDatetime($timeFixed))->isIdenticalTo('2011-04-26 11:57');
+    }
 }

--- a/Tests/Units/Middlewares/Identification.php
+++ b/Tests/Units/Middlewares/Identification.php
@@ -17,6 +17,7 @@ final class Identification extends \Atoum
 
     public function beforeTestMethod($method)
     {
+        parent::beforeTestMethod($method);
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->request = new \mock\Slim\Http\Request();

--- a/Tests/Units/Middlewares/Identification.php
+++ b/Tests/Units/Middlewares/Identification.php
@@ -15,21 +15,43 @@ final class Identification extends \Atoum
      */
     private $request;
 
+    /**
+     * @var \mock\App\Components\Utilisateur\Repository
+     */
+    private $repository;
+
     public function beforeTestMethod($method)
     {
         parent::beforeTestMethod($method);
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->request = new \mock\Slim\Http\Request();
+        $this->calling($this->request)->getHeaderLine = 'token';
+        $this->mockGenerator->orphanize('__construct');
+        $this->repository = new \mock\App\Components\Utilisateur\Repository();
     }
 
     /**
      * Teste si le token api est bon
      */
-    public function testIsTokenApiOkOk()
+    public function testIsTokenOkOk()
     {
-        $auth = new _Identification($this->request);
+        $this->calling($this->repository)->find = function () {
+            return new \App\Components\Utilisateur\Model([]);
+        };
+        $auth = new _Identification($this->request, $this->repository);
 
-        $this->boolean($auth->isTokenApiOk())->isTrue();
+        $this->boolean($auth->isTokenOk())->isTrue();
+    }
+
+    /**
+     * Teste si le token api est ko
+     */
+    public function testIsTokenOkKo()
+    {
+        $this->calling($this->repository)->find = null;
+        $auth = new _Identification($this->request, $this->repository);
+
+        $this->boolean($auth->isTokenOk())->isFalse();
     }
 }

--- a/configuration.json.example
+++ b/configuration.json.example
@@ -1,7 +1,7 @@
 {
     "db": {
         "serveur": "",
-        "database": "",
+        "base": "",
         "utilisateur": "",
         "mot_de_passe" : ""
     }


### PR DESCRIPTION
Fix #16 
Fix #15

Le mécanisme de gestion de token a été très erratique. La dernière version en date, ici, créé un token pour une durée de 5 minutes (repoussée à chaque nouvelle requête) et génère un champ avec des caractères spéciaux mais utilisables dans une requête (pas comme la précédente). Sécurisé mais potentiellement reversible, cette version rendra un meilleur service. À présent, toutes les requêtes (sauf l'authentification) devront montrer patte blanche avec la transmission du token via le header `Token [aaaaaa]`.

Testable facilement avec un docker + l'addon httpRequester