### PR TITLE
Changement de nom vers Entité

### DIFF
--- a/App/Components/Planning/Controller.php
+++ b/App/Components/Planning/Controller.php
@@ -109,11 +109,11 @@ final class Controller extends \App\Libraries\AController
     /**
      * Construit le « data » du json
      *
-     * @param Model $entite Planning
+     * @param Entite $entite Planning
      *
      * @return array
      */
-    private function buildData(Model $entite)
+    private function buildData(Entite $entite)
     {
         return [
             'id' => $entite->getId(),
@@ -143,7 +143,7 @@ final class Controller extends \App\Libraries\AController
         }
 
         try {
-            $planningId = $this->repository->postOne($body, new Model([]));
+            $planningId = $this->repository->postOne($body, new Entite([]));
             $code = 201;
             $data = [
                 'code' => $code,

--- a/App/Components/Planning/Controller.php
+++ b/App/Components/Planning/Controller.php
@@ -86,16 +86,16 @@ final class Controller extends \App\Libraries\AController
             $plannings = $this->repository->getList(
                 $request->getQueryParams()
             );
-            $models = [];
+            $entites = [];
             foreach ($plannings as $planning) {
-                $models[] = $this->buildData($planning);
+                $entites[] = $this->buildData($planning);
             }
             $code = 200;
             $data = [
                 'code' => $code,
                 'status' => 'success',
                 'message' => '',
-                'data' => $models,
+                'data' => $entites,
             ];
 
             return $response->withJson($data, $code);
@@ -109,16 +109,16 @@ final class Controller extends \App\Libraries\AController
     /**
      * Construit le « data » du json
      *
-     * @param Model $model Planning
+     * @param Model $entite Planning
      *
      * @return array
      */
-    private function buildData(Model $model)
+    private function buildData(Model $entite)
     {
         return [
-            'id' => $model->getId(),
-            'name' => $model->getName(),
-            'status' => $model->getStatus(),
+            'id' => $entite->getId(),
+            'name' => $entite->getName(),
+            'status' => $entite->getStatus(),
         ];
     }
 

--- a/App/Components/Planning/Creneau/Controller.php
+++ b/App/Components/Planning/Creneau/Controller.php
@@ -96,16 +96,16 @@ final class Controller extends \App\Libraries\AController
         $data = [];
         try {
             $creneaux = $this->repository->getList(['planningId' => $planningId]);
-            $models = [];
+            $entites = [];
             foreach ($creneaux as $creneau) {
-                $models[] = $this->buildData($creneau);
+                $entites[] = $this->buildData($creneau);
             }
             $code = 200;
             $data = [
                 'code' => $code,
                 'status' => 'success',
                 'message' => '',
-                'data' => $models,
+                'data' => $entites,
             ];
 
             return $response->withJson($data, $code);
@@ -119,20 +119,20 @@ final class Controller extends \App\Libraries\AController
     /**
      * Construit le « data » du json
      *
-     * @param Model $model Créneau de planning
+     * @param Model $entite Créneau de planning
      *
      * @return array
      */
-    private function buildData(Model $model)
+    private function buildData(Model $entite)
     {
         return [
-            'id' => $model->getId(),
-            'planningId' => $model->getPlanningId(),
-            'jourId' => $model->getJourId(),
-            'typeSemaine' => $model->getTypeSemaine(),
-            'typePeriode' => $model->getTypePeriode(),
-            'debut' => $model->getDebut(),
-            'fin' => $model->getFin(),
+            'id' => $entite->getId(),
+            'planningId' => $entite->getPlanningId(),
+            'jourId' => $entite->getJourId(),
+            'typeSemaine' => $entite->getTypeSemaine(),
+            'typePeriode' => $entite->getTypePeriode(),
+            'debut' => $entite->getDebut(),
+            'fin' => $entite->getFin(),
         ];
     }
 

--- a/App/Components/Planning/Creneau/Controller.php
+++ b/App/Components/Planning/Creneau/Controller.php
@@ -119,11 +119,11 @@ final class Controller extends \App\Libraries\AController
     /**
      * Construit le « data » du json
      *
-     * @param Model $entite Créneau de planning
+     * @param Entite $entite Créneau de planning
      *
      * @return array
      */
-    private function buildData(Model $entite)
+    private function buildData(Entite $entite)
     {
         return [
             'id' => $entite->getId(),
@@ -157,7 +157,7 @@ final class Controller extends \App\Libraries\AController
         }
 
         try {
-            $creneauxIds = $this->repository->postList($body, new Model([]));
+            $creneauxIds = $this->repository->postList($body, new Entite([]));
             $dataMessage = [];
             foreach ($creneauxIds as $id) {
                 $dataMessage[] = $this->router->pathFor('getPlanningCreneauDetail', [

--- a/App/Components/Planning/Creneau/Entite.php
+++ b/App/Components/Planning/Creneau/Entite.php
@@ -8,12 +8,12 @@ namespace App\Components\Planning\Creneau;
  * @author Wouldsmina
  *
  * @since 0.1
- * @see \Tests\Units\App\Components\Planning\Creneau\Model
+ * @see \Tests\Units\App\Components\Planning\Creneau\Entite
  *
  * Ne devrait être contacté que par le Planning\Creneau\Repository
  * Ne devrait contacter personne
  */
-class Model extends \App\Libraries\AModel
+class Entite extends \App\Libraries\AEntite
 {
     /**
      * Retourne la donnée la plus à jour du champ planning id

--- a/App/Components/Planning/Creneau/Repository.php
+++ b/App/Components/Planning/Creneau/Repository.php
@@ -2,7 +2,7 @@
 namespace App\Components\Planning\Creneau;
 
 use App\Exceptions\MissingArgumentException;
-use App\Libraries\AModel;
+use App\Libraries\AEntite;
 
 /**
  * {@inheritDoc}
@@ -14,7 +14,7 @@ use App\Libraries\AModel;
  * @see \Tests\Units\App\Components\Planning\Repository
  *
  * Ne devrait être contacté que par le Planning\Creneau\Controller, Planning\Repository
- * Ne devrait contacter que le Planning\Creneau\Model, Planning\Creneau\Dao
+ * Ne devrait contacter que le Planning\Creneau\Entite, Planning\Creneau\Dao
  */
 class Repository extends \App\Libraries\ARepository
 {
@@ -35,7 +35,7 @@ class Repository extends \App\Libraries\ARepository
             throw new \DomainException('Creneau#' . $id . ' is not a valid resource');
         }
 
-        return new Model($this->getDataDao2Model($data));
+        return new Entite($this->getDataDao2Entite($data));
     }
 
     /**
@@ -51,7 +51,7 @@ class Repository extends \App\Libraries\ARepository
 
         $entites = [];
         foreach ($data as $value) {
-            $entite = new Model($this->getDataDao2Model($value));
+            $entite = new Entite($this->getDataDao2Entite($value));
             $entites[$entite->getId()] = $entite;
         }
 
@@ -61,7 +61,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getDataDao2Model(array $dataDao)
+    final protected function getDataDao2Entite(array $dataDao)
     {
         return [
             'id' => $dataDao['creneau_id'],
@@ -102,13 +102,13 @@ class Repository extends \App\Libraries\ARepository
      * Poste une liste de ressource
      *
      * @param array $data Tableau de données à poster
-     * @param AModel $entite [Vide par définition]
+     * @param AEntite $entite [Vide par définition]
      *
      * @return array Tableau d'id des créneaux nouvellement créés
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    public function postList(array $data, AModel $entite)
+    public function postList(array $data, AEntite $entite)
     {
         $postIds = [];
         $this->dao->beginTransaction();
@@ -133,7 +133,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AModel $entite)
+    public function postOne(array $data, AEntite $entite)
     {
         if (!$this->hasAllRequired($data)) {
             throw new MissingArgumentException('');
@@ -141,7 +141,7 @@ class Repository extends \App\Libraries\ARepository
 
         try {
             $entite->populate($data);
-            $dataDao = $this->getModel2DataDao($entite);
+            $dataDao = $this->getEntite2DataDao($entite);
 
             return $this->dao->post($dataDao);
         } catch (\Exception $e) {
@@ -152,7 +152,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getModel2DataDao(AModel $entite)
+    final protected function getEntite2DataDao(AEntite $entite)
     {
         return [
             'planning_id' => $entite->getPlanningId(),
@@ -199,7 +199,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function putOne(array $data, AModel $entite)
+    public function putOne(array $data, AEntite $entite)
     {
         if (!$this->hasAllRequired($data)) {
             throw new MissingArgumentException('');
@@ -207,7 +207,7 @@ class Repository extends \App\Libraries\ARepository
 
         try {
             $entite->populate($data);
-            $dataDao = $this->getModel2DataDao($entite);
+            $dataDao = $this->getEntite2DataDao($entite);
 
             return $this->dao->put($dataDao, $entite->getId());
         } catch (\Exception $e) {
@@ -222,7 +222,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AModel $entite)
+    public function deleteOne(AEntite $entite)
     {
     }
 }

--- a/App/Components/Planning/Creneau/Repository.php
+++ b/App/Components/Planning/Creneau/Repository.php
@@ -49,13 +49,13 @@ class Repository extends \App\Libraries\ARepository
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $models = [];
+        $entites = [];
         foreach ($data as $value) {
-            $model = new Model($this->getDataDao2Model($value));
-            $models[$model->getId()] = $model;
+            $entite = new Model($this->getDataDao2Model($value));
+            $entites[$entite->getId()] = $entite;
         }
 
-        return $models;
+        return $entites;
     }
 
     /**
@@ -102,24 +102,24 @@ class Repository extends \App\Libraries\ARepository
      * Poste une liste de ressource
      *
      * @param array $data Tableau de données à poster
-     * @param AModel $model [Vide par définition]
+     * @param AModel $entite [Vide par définition]
      *
      * @return array Tableau d'id des créneaux nouvellement créés
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    public function postList(array $data, AModel $model)
+    public function postList(array $data, AModel $entite)
     {
         $postIds = [];
         $this->dao->beginTransaction();
         foreach ($data as $creneau) {
             try {
-                $postIds[] = $this->postOne($creneau, $model);
+                $postIds[] = $this->postOne($creneau, $entite);
                 /*
                  * Le plus cool aurait été de cloner l'objet de base,
                  * mais le clonage de mock est nul, donc on reset pour la boucle
                  */
-                $model->reset();
+                $entite->reset();
             } catch (\Exception $e) {
                 $this->dao->rollback();
                 throw $e;
@@ -133,15 +133,15 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AModel $model)
+    public function postOne(array $data, AModel $entite)
     {
         if (!$this->hasAllRequired($data)) {
             throw new MissingArgumentException('');
         }
 
         try {
-            $model->populate($data);
-            $dataDao = $this->getModel2DataDao($model);
+            $entite->populate($data);
+            $dataDao = $this->getModel2DataDao($entite);
 
             return $this->dao->post($dataDao);
         } catch (\Exception $e) {
@@ -152,15 +152,15 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getModel2DataDao(AModel $model)
+    final protected function getModel2DataDao(AModel $entite)
     {
         return [
-            'planning_id' => $model->getPlanningId(),
-            'jour_id' => $model->getJourId(),
-            'type_semaine' => $model->getTypeSemaine(),
-            'type_periode' => $model->getTypePeriode(),
-            'debut' => $model->getDebut(),
-            'fin' => $model->getFin(),
+            'planning_id' => $entite->getPlanningId(),
+            'jour_id' => $entite->getJourId(),
+            'type_semaine' => $entite->getTypeSemaine(),
+            'type_periode' => $entite->getTypePeriode(),
+            'debut' => $entite->getDebut(),
+            'fin' => $entite->getFin(),
         ];
     }
 
@@ -199,17 +199,17 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function putOne(array $data, AModel $model)
+    public function putOne(array $data, AModel $entite)
     {
         if (!$this->hasAllRequired($data)) {
             throw new MissingArgumentException('');
         }
 
         try {
-            $model->populate($data);
-            $dataDao = $this->getModel2DataDao($model);
+            $entite->populate($data);
+            $dataDao = $this->getModel2DataDao($entite);
 
-            return $this->dao->put($dataDao, $model->getId());
+            return $this->dao->put($dataDao, $entite->getId());
         } catch (\Exception $e) {
             throw $e;
         }
@@ -222,7 +222,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AModel $model)
+    public function deleteOne(AModel $entite)
     {
     }
 }

--- a/App/Components/Planning/Entite.php
+++ b/App/Components/Planning/Entite.php
@@ -8,12 +8,12 @@ namespace App\Components\Planning;
  * @author Wouldsmina
  *
  * @since 0.1
- * @see \Tests\Units\App\Components\Planning\Model
+ * @see \Tests\Units\App\Components\Planning\Entite
  *
  * Ne devrait être contacté que par le Planning\Repository
  * Ne devrait contacter personne
  */
-class Model extends \App\Libraries\AModel
+class Entite extends \App\Libraries\AEntite
 {
     /**
      * Retourne la donnée la plus à jour du champ name

--- a/App/Components/Planning/Repository.php
+++ b/App/Components/Planning/Repository.php
@@ -2,7 +2,7 @@
 namespace App\Components\Planning;
 
 use App\Exceptions\MissingArgumentException;
-use App\Libraries\AModel;
+use App\Libraries\AEntite;
 
 /**
  * {@inheritDoc}
@@ -14,7 +14,7 @@ use App\Libraries\AModel;
  * @see \Tests\Units\App\Components\Planning\Repository
  *
  * Ne devrait être contacté que par le Planning\Controller
- * Ne devrait contacter que le Planning\Model, Planning\Dao
+ * Ne devrait contacter que le Planning\Entite, Planning\Dao
  */
 class Repository extends \App\Libraries\ARepository
 {
@@ -33,7 +33,7 @@ class Repository extends \App\Libraries\ARepository
             throw new \DomainException('Planning#' . $id . ' is not a valid resource');
         }
 
-        return new Model($this->getDataDao2Model($data));
+        return new Entite($this->getDataDao2Entite($data));
     }
 
     /**
@@ -55,7 +55,7 @@ class Repository extends \App\Libraries\ARepository
 
         $entites = [];
         foreach ($data as $value) {
-            $entite = new Model($this->getDataDao2Model($value));
+            $entite = new Entite($this->getDataDao2Entite($value));
             $entites[$entite->getId()] = $entite;
         }
 
@@ -65,7 +65,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getDataDao2Model(array $dataDao)
+    final protected function getDataDao2Entite(array $dataDao)
     {
         return [
             'id' => $dataDao['planning_id'],
@@ -107,7 +107,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AModel $entite)
+    public function postOne(array $data, AEntite $entite)
     {
         if (!$this->hasAllRequired($data)) {
             throw new MissingArgumentException('');
@@ -115,7 +115,7 @@ class Repository extends \App\Libraries\ARepository
 
         try {
             $entite->populate($data);
-            $dataDao = $this->getModel2DataDao($entite);
+            $dataDao = $this->getEntite2DataDao($entite);
 
             return $this->dao->post($dataDao);
         } catch (\Exception $e) {
@@ -126,7 +126,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getModel2DataDao(AModel $entite)
+    final protected function getEntite2DataDao(AEntite $entite)
     {
         return [
             'name' => $entite->getName(),
@@ -169,7 +169,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function putOne(array $data, AModel $entite)
+    public function putOne(array $data, AEntite $entite)
     {
         if (!$this->hasAllRequired($data)) {
             throw new MissingArgumentException('');
@@ -177,7 +177,7 @@ class Repository extends \App\Libraries\ARepository
 
         try {
             $entite->populate($data);
-            $dataDao = $this->getModel2DataDao($entite);
+            $dataDao = $this->getEntite2DataDao($entite);
 
             return $this->dao->put($dataDao, $entite->getId());
         } catch (\Exception $e) {
@@ -192,7 +192,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AModel $entite)
+    public function deleteOne(AEntite $entite)
     {
         try {
             $entite->reset();

--- a/App/Components/Planning/Repository.php
+++ b/App/Components/Planning/Repository.php
@@ -53,13 +53,13 @@ class Repository extends \App\Libraries\ARepository
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $models = [];
+        $entites = [];
         foreach ($data as $value) {
-            $model = new Model($this->getDataDao2Model($value));
-            $models[$model->getId()] = $model;
+            $entite = new Model($this->getDataDao2Model($value));
+            $entites[$entite->getId()] = $entite;
         }
 
-        return $models;
+        return $entites;
     }
 
     /**
@@ -107,15 +107,15 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AModel $model)
+    public function postOne(array $data, AModel $entite)
     {
         if (!$this->hasAllRequired($data)) {
             throw new MissingArgumentException('');
         }
 
         try {
-            $model->populate($data);
-            $dataDao = $this->getModel2DataDao($model);
+            $entite->populate($data);
+            $dataDao = $this->getModel2DataDao($entite);
 
             return $this->dao->post($dataDao);
         } catch (\Exception $e) {
@@ -126,11 +126,11 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getModel2DataDao(AModel $model)
+    final protected function getModel2DataDao(AModel $entite)
     {
         return [
-            'name' => $model->getName(),
-            'status' => $model->getStatus(),
+            'name' => $entite->getName(),
+            'status' => $entite->getStatus(),
         ];
     }
 
@@ -169,17 +169,17 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function putOne(array $data, AModel $model)
+    public function putOne(array $data, AModel $entite)
     {
         if (!$this->hasAllRequired($data)) {
             throw new MissingArgumentException('');
         }
 
         try {
-            $model->populate($data);
-            $dataDao = $this->getModel2DataDao($model);
+            $entite->populate($data);
+            $dataDao = $this->getModel2DataDao($entite);
 
-            return $this->dao->put($dataDao, $model->getId());
+            return $this->dao->put($dataDao, $entite->getId());
         } catch (\Exception $e) {
             throw $e;
         }
@@ -192,11 +192,11 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AModel $model)
+    public function deleteOne(AModel $entite)
     {
         try {
-            $model->reset();
-            $this->dao->delete($model->getId());
+            $entite->reset();
+            $this->dao->delete($entite->getId());
         } catch (\Exception $e) {
             throw $e;
         }

--- a/App/Components/Utilisateur/Entite.php
+++ b/App/Components/Utilisateur/Entite.php
@@ -49,7 +49,7 @@ class Entite extends \App\Libraries\AEntite
     }
 
     /**
-     * Insère le token dans le modèle
+     * Insère le token dans l'entité
      *
      * @param string $token Nouveau token d'indentification utilisateur
      *
@@ -94,7 +94,7 @@ class Entite extends \App\Libraries\AEntite
 
     /**
      * @inheritDoc
-     * @TODO Le modèle utilisateur n'a pas de clé primaire en int, donc on surcharge le parent. Mettre une PK en int !
+     * @TODO L'entité utilisateur n'a pas de clé primaire en int, donc on surcharge le parent. Mettre une PK en int !
      */
     final protected function setId($id)
     {

--- a/App/Components/Utilisateur/Entite.php
+++ b/App/Components/Utilisateur/Entite.php
@@ -10,12 +10,12 @@ use App\Helpers\Formatter;
  * @author Wouldsmina
  *
  * @since 0.2
- * @see \Tests\Units\App\Components\Utilisateur\Model
+ * @see \Tests\Units\App\Components\Utilisateur\Entite
  *
  * Ne devrait être contacté que par le Utilisateur\Repository
  * Ne devrait contacter personne
  */
-class Model extends \App\Libraries\AModel
+class Entite extends \App\Libraries\AEntite
 {
     public function getToken()
     {

--- a/App/Components/Utilisateur/Repository.php
+++ b/App/Components/Utilisateur/Repository.php
@@ -151,7 +151,7 @@ class Repository extends \App\Libraries\ARepository
     public function updateDateLastAccess(AEntite $entite)
     {
         $entite->updateDateLastAccess();
-        $dataDao = $this->getModel2DataDao($entite);
+        $dataDao = $this->getEntite2DataDao($entite);
         $this->dao->put($dataDao, $entite->getId());
     }
 

--- a/App/Components/Utilisateur/Repository.php
+++ b/App/Components/Utilisateur/Repository.php
@@ -68,13 +68,13 @@ class Repository extends \App\Libraries\ARepository
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $models = [];
+        $entites = [];
         foreach ($data as $value) {
-            $model = new Model($this->getDataDao2Model($value));
-            $models[$model->getId()] = $model;
+            $entite = new Model($this->getDataDao2Model($value));
+            $entites[$entite->getId()] = $entite;
         }
 
-        return $models;
+        return $entites;
     }
 
     /**
@@ -129,7 +129,7 @@ class Repository extends \App\Libraries\ARepository
      * POST
      *************************************************/
 
-    public function postOne(array $data, AModel $model)
+    public function postOne(array $data, AModel $entite)
     {
     }
 
@@ -137,7 +137,7 @@ class Repository extends \App\Libraries\ARepository
      * PUT
      *************************************************/
 
-    public function putOne(array $data, AModel $model)
+    public function putOne(array $data, AModel $entite)
     {
     }
 
@@ -148,7 +148,7 @@ class Repository extends \App\Libraries\ARepository
      *
      * @since 0.3
      */
-    public function updateDateLastAccess(Model $model)
+    public function updateDateLastAccess(AModel $model)
     {
         $model->updateDateLastAccess();
         $dataDao = $this->getModel2DataDao($model);
@@ -158,12 +158,12 @@ class Repository extends \App\Libraries\ARepository
     /**
      * Regénère le token de l'utilisateur pour une nouvelle session
      *
-     * @param AModel $model Modèle utilisateur
+     * @param AModel $entite Modèle utilisateur
      *
      * @return AModel Le modèle hydraté du nouveau token
      * @throws \RuntimeException Si le token instance n'est pas posé
      */
-    public function regenerateToken(AModel $model)
+    public function regenerateToken(AModel $entite)
     {
         $instanceToken = $this->application->getTokenInstance();
         if (empty($instanceToken)) {
@@ -171,12 +171,12 @@ class Repository extends \App\Libraries\ARepository
         }
 
         try {
-            $model->populateToken($this->buildToken($instanceToken));
-            $model->updateDateLastAccess();
-            $dataDao = $this->getModel2DataDao($model);
-            $this->dao->put($dataDao, $model->getId());
+            $entite->populateToken($this->buildToken($instanceToken));
+            $entite->updateDateLastAccess();
+            $dataDao = $this->getModel2DataDao($entite);
+            $this->dao->put($dataDao, $entite->getId());
 
-            return $model;
+            return $entite;
         } catch (\Exception $e) {
             throw $e;
         }
@@ -185,26 +185,26 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getModel2DataDao(AModel $model)
+    final protected function getModel2DataDao(AModel $entite)
     {
         return [
-            //'u_login' => $model->getLogin(), // PK ne doit pas être vu par la DAO
-            /*'u_nom' => $model->getJourId(),
-            'u_prenom' => $model->getTypeSemaine(),
-            'u_is_resp' => $model->getTypePeriode(),
-            'u_is_admin' => $model->getDebut(),
-            'u_is_hr' => $model->getFin(),
-            'u_is_active' => $model->getFin(),
-            'u_see_all' => $model->getFin(),
-            'u_passwd' => $model->getFin(),
-            'u_quotite' => $model->getFin(),
-            'u_email' => $model->getFin(),
-            'u_num_exercice' => $model->getFin(),
-            'planning_id' => $model->getFin(),
-            'u_heure_solde' => $model->getFin(),
-            'date_inscription' => $model->getFin(),*/
-            'token' => $model->getToken(),
-            'date_last_access' => $model->getDateLastAccess(),
+            //'u_login' => $entite->getLogin(), // PK ne doit pas être vu par la DAO
+            /*'u_nom' => $entite->getJourId(),
+            'u_prenom' => $entite->getTypeSemaine(),
+            'u_is_resp' => $entite->getTypePeriode(),
+            'u_is_admin' => $entite->getDebut(),
+            'u_is_hr' => $entite->getFin(),
+            'u_is_active' => $entite->getFin(),
+            'u_see_all' => $entite->getFin(),
+            'u_passwd' => $entite->getFin(),
+            'u_quotite' => $entite->getFin(),
+            'u_email' => $entite->getFin(),
+            'u_num_exercice' => $entite->getFin(),
+            'planning_id' => $entite->getFin(),
+            'u_heure_solde' => $entite->getFin(),
+            'date_inscription' => $entite->getFin(),*/
+            'token' => $entite->getToken(),
+            'date_last_access' => $entite->getDateLastAccess(),
         ];
     }
 
@@ -224,7 +224,7 @@ class Repository extends \App\Libraries\ARepository
      * DELETE
      *************************************************/
 
-    public function deleteOne(AModel $model)
+    public function deleteOne(AModel $entite)
     {
     }
 }

--- a/App/Components/Utilisateur/Repository.php
+++ b/App/Components/Utilisateur/Repository.php
@@ -1,7 +1,7 @@
 <?php
 namespace App\Components\Utilisateur;
 
-use App\Libraries\AModel;
+use App\Libraries\AEntite;
 use App\Libraries\Application;
 
 /**
@@ -13,8 +13,8 @@ use App\Libraries\Application;
  * @since 0.2
  * @see \Tests\Units\App\Components\Utilisateur\Repository
  *
- * Ne devrait être contacté que par le Authentification\Controller et \Middlewares\Identification
- * Ne devrait contacter que le Utilisateur\Model, Utilisateur\Dao
+ * Ne devrait être contacté que par le Authentification\Controller
+ * Ne devrait contacter que le Utilisateur\Entite, Utilisateur\Dao
  */
 class Repository extends \App\Libraries\ARepository
 {
@@ -50,7 +50,7 @@ class Repository extends \App\Libraries\ARepository
      * @param array $parametres
      * @example [offset => 4, start-after => 23, filter => 'name::chapo|status::1,3']
      *
-     * @return AModel
+     * @return AEntite
      */
     public function find(array $parametres)
     {
@@ -70,7 +70,7 @@ class Repository extends \App\Libraries\ARepository
 
         $entites = [];
         foreach ($data as $value) {
-            $entite = new Model($this->getDataDao2Model($value));
+            $entite = new Entite($this->getDataDao2Entite($value));
             $entites[$entite->getId()] = $entite;
         }
 
@@ -80,7 +80,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getDataDao2Model(array $dataDao)
+    final protected function getDataDao2Entite(array $dataDao)
     {
         return [
             'id' => $dataDao['id'],
@@ -129,7 +129,7 @@ class Repository extends \App\Libraries\ARepository
      * POST
      *************************************************/
 
-    public function postOne(array $data, AModel $entite)
+    public function postOne(array $data, AEntite $entite)
     {
     }
 
@@ -137,33 +137,33 @@ class Repository extends \App\Libraries\ARepository
      * PUT
      *************************************************/
 
-    public function putOne(array $data, AModel $entite)
+    public function putOne(array $data, AEntite $entite)
     {
     }
 
     /**
      * « Ping » la date de dernier accès de l'utilisateur
      *
-     * @param Model $model Modèle utilisateur
+     * @param AEntite $entite Entité utilisateur
      *
      * @since 0.3
      */
-    public function updateDateLastAccess(AModel $model)
+    public function updateDateLastAccess(AEntite $entite)
     {
-        $model->updateDateLastAccess();
-        $dataDao = $this->getModel2DataDao($model);
-        $this->dao->put($dataDao, $model->getId());
+        $entite->updateDateLastAccess();
+        $dataDao = $this->getModel2DataDao($entite);
+        $this->dao->put($dataDao, $entite->getId());
     }
 
     /**
      * Regénère le token de l'utilisateur pour une nouvelle session
      *
-     * @param AModel $entite Modèle utilisateur
+     * @param AEntite $entite Entité utilisateur
      *
-     * @return AModel Le modèle hydraté du nouveau token
+     * @return AEntite L'entité hydratée du nouveau token
      * @throws \RuntimeException Si le token instance n'est pas posé
      */
-    public function regenerateToken(AModel $entite)
+    public function regenerateToken(AEntite $entite)
     {
         $instanceToken = $this->application->getTokenInstance();
         if (empty($instanceToken)) {
@@ -173,7 +173,7 @@ class Repository extends \App\Libraries\ARepository
         try {
             $entite->populateToken($this->buildToken($instanceToken));
             $entite->updateDateLastAccess();
-            $dataDao = $this->getModel2DataDao($entite);
+            $dataDao = $this->getEntite2DataDao($entite);
             $this->dao->put($dataDao, $entite->getId());
 
             return $entite;
@@ -185,7 +185,7 @@ class Repository extends \App\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    final protected function getModel2DataDao(AModel $entite)
+    final protected function getEntite2DataDao(AEntite $entite)
     {
         return [
             //'u_login' => $entite->getLogin(), // PK ne doit pas être vu par la DAO
@@ -224,7 +224,7 @@ class Repository extends \App\Libraries\ARepository
      * DELETE
      *************************************************/
 
-    public function deleteOne(AModel $entite)
+    public function deleteOne(AEntite $entite)
     {
     }
 }

--- a/App/Libraries/AEntite.php
+++ b/App/Libraries/AEntite.php
@@ -13,7 +13,7 @@ namespace App\Libraries;
  * Ne devrait être contacté par personne
  * Ne devrait contacter personne
  */
-abstract class AModel
+abstract class AEntite
 {
     /**
      * @var int $id Identifiant unique de l'élément dans la liste

--- a/App/Libraries/AEntite.php
+++ b/App/Libraries/AEntite.php
@@ -63,7 +63,7 @@ abstract class AEntite
     }
 
     /**
-     * Insère massivement des nouvelles données dans le modèle
+     * Insère massivement des nouvelles données dans l'entité
      *
      * @param array $data Données à insérer / mettre à jour
      *

--- a/App/Libraries/ARepository.php
+++ b/App/Libraries/ARepository.php
@@ -78,11 +78,11 @@ abstract class ARepository
     /**
      * Effectue le mapping des éléments venant du modèle pour qu'ils soient compréhensibles pour la DAO
      *
-     * @param AModel $model
+     * @param AModel $entite
      *
      * @return array
      */
-    abstract protected function getModel2DataDao(AModel $model);
+    abstract protected function getModel2DataDao(AModel $entite);
 
     /*************************************************
      * POST
@@ -92,13 +92,13 @@ abstract class ARepository
      * Poste une ressource unique
      *
      * @param array $data Données à poster
-     * @param AModel $model [Vide par définition]
+     * @param AModel $entite [Vide par définition]
      *
      * @return int Id de la ressource nouvellement insérée
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    abstract public function postOne(array $data, AModel $model);
+    abstract public function postOne(array $data, AModel $entite);
 
     /*************************************************
      * PUT
@@ -108,12 +108,12 @@ abstract class ARepository
      * Met à jour une ressource unique
      *
      * @param array $data Données à mettre à jour
-     * @param AModel $model
+     * @param AModel $entite
      *
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    abstract public function putOne(array $data, AModel $model);
+    abstract public function putOne(array $data, AModel $entite);
 
     /*************************************************
      * DELETE
@@ -122,7 +122,7 @@ abstract class ARepository
     /**
      * Détruit une ressource unique
      *
-     * @param AModel $model
+     * @param AModel $entite
      */
-    abstract public function deleteOne(AModel $model);
+    abstract public function deleteOne(AModel $entite);
 }

--- a/App/Libraries/ARepository.php
+++ b/App/Libraries/ARepository.php
@@ -4,7 +4,7 @@ namespace App\Libraries;
 use App\Exceptions\MissingArgumentException;
 
 /**
- * Garant de la cohérence métier du modèle en relation.
+ * Garant de la cohérence métier de l'entité en relation.
  * Autrement dit, c'est lui qui va chercher les données (dépendances comprises),
  * pour construire un Domain model bien formé
  *
@@ -54,7 +54,7 @@ abstract class ARepository
     abstract public function getList(array $parametres);
 
     /**
-     * Effectue le mapping des éléments venant de la DAO pour qu'ils soient compréhensibles pour le Modèle
+     * Effectue le mapping des éléments venant de la DAO pour qu'ils soient compréhensibles pour l'Entité
      *
      * @param array $dataDao
      *
@@ -76,7 +76,7 @@ abstract class ARepository
     abstract protected function getParamsConsumer2Dao(array $paramsConsumer);
 
     /**
-     * Effectue le mapping des éléments venant du modèle pour qu'ils soient compréhensibles pour la DAO
+     * Effectue le mapping des éléments venant de l'entité pour qu'ils soient compréhensibles pour la DAO
      *
      * @param AEntite $entite
      *

--- a/App/Libraries/ARepository.php
+++ b/App/Libraries/ARepository.php
@@ -37,7 +37,7 @@ abstract class ARepository
      *
      * @param int $id Id potentiel de ressource
      *
-     * @return \App\Libraries\AModel
+     * @return \App\Libraries\AEntite
      * @throws \DomainException Si $id n'est pas dans le domaine de définition
      */
     abstract public function getOne($id);
@@ -60,7 +60,7 @@ abstract class ARepository
      *
      * @return array
      */
-    abstract protected function getDataDao2Model(array $dataDao);
+    abstract protected function getDataDao2Entite(array $dataDao);
 
     /**
      * Effectue le mapping des recherches du consommateur de l'API pour qu'elles
@@ -78,11 +78,11 @@ abstract class ARepository
     /**
      * Effectue le mapping des éléments venant du modèle pour qu'ils soient compréhensibles pour la DAO
      *
-     * @param AModel $entite
+     * @param AEntite $entite
      *
      * @return array
      */
-    abstract protected function getModel2DataDao(AModel $entite);
+    abstract protected function getEntite2DataDao(AEntite $entite);
 
     /*************************************************
      * POST
@@ -92,13 +92,13 @@ abstract class ARepository
      * Poste une ressource unique
      *
      * @param array $data Données à poster
-     * @param AModel $entite [Vide par définition]
+     * @param AEntite $entite [Vide par définition]
      *
      * @return int Id de la ressource nouvellement insérée
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    abstract public function postOne(array $data, AModel $entite);
+    abstract public function postOne(array $data, AEntite $entite);
 
     /*************************************************
      * PUT
@@ -108,12 +108,12 @@ abstract class ARepository
      * Met à jour une ressource unique
      *
      * @param array $data Données à mettre à jour
-     * @param AModel $entite
+     * @param AEntite $entite
      *
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    abstract public function putOne(array $data, AModel $entite);
+    abstract public function putOne(array $data, AEntite $entite);
 
     /*************************************************
      * DELETE
@@ -122,7 +122,7 @@ abstract class ARepository
     /**
      * Détruit une ressource unique
      *
-     * @param AModel $entite
+     * @param AEntite $entite
      */
-    abstract public function deleteOne(AModel $entite);
+    abstract public function deleteOne(AEntite $entite);
 }

--- a/Middlewares/Identification.php
+++ b/Middlewares/Identification.php
@@ -1,7 +1,7 @@
 <?php
 namespace Middlewares;
 
-use App\Libraries\AModel;
+use App\Libraries\AEntite;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use App\Helpers\Formatter;
 
@@ -17,7 +17,7 @@ final class Identification
      */
     const DUREE_SESSION = 30*60;
     /**
-     * @var \App\Libraries\AModel
+     * @var \App\Libraries\AEntite
      */
     private $utilisateur;
 
@@ -54,7 +54,7 @@ final class Identification
      */
     public function isTokenOk()
     {
-        return $this->getUtilisateur() instanceof AModel;
+        return $this->getUtilisateur() instanceof AEntite;
     }
 
     /**

--- a/Tests/Units/App/Components/Authentification/Controller.php
+++ b/Tests/Units/App/Components/Authentification/Controller.php
@@ -21,7 +21,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     /**
      * @var \mock\App\Components\Utilisateur\Model Mock du modèle associé
      */
-    private $model;
+    private $entite;
 
     /**
      * Init des tests
@@ -33,7 +33,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
         $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\App\Components\Utilisateur\Repository();
         $this->mockGenerator->orphanize('__construct');
-        $this->model = new \mock\App\Components\Utilisateur\Model();
+        $this->entite = new \mock\App\Components\Utilisateur\Model();
     }
 
     /*************************************************
@@ -79,9 +79,9 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testGetFound()
     {
         $token = 'abcde';
-        $this->model->getMockController()->getToken = $token;
-        $this->repository->getMockController()->find = $this->model;
-        $this->repository->getMockController()->regenerateToken = $this->model;
+        $this->entite->getMockController()->getToken = $token;
+        $this->repository->getMockController()->find = $this->entite;
+        $this->repository->getMockController()->regenerateToken = $this->entite;
         $this->request->getMockController()->getHeaderLine = 'Basic QWxhZGRpbjpPcGVuU2VzYW1l';
         $controller = new _Controller($this->repository, $this->router);
 

--- a/Tests/Units/App/Components/Authentification/Controller.php
+++ b/Tests/Units/App/Components/Authentification/Controller.php
@@ -19,7 +19,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     private $repository;
 
     /**
-     * @var \mock\App\Components\Utilisateur\Model Mock du modèle associé
+     * @var \mock\App\Components\Utilisateur\Entite Mock de l'entité associée
      */
     private $entite;
 
@@ -33,7 +33,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
         $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\App\Components\Utilisateur\Repository();
         $this->mockGenerator->orphanize('__construct');
-        $this->entite = new \mock\App\Components\Utilisateur\Model();
+        $this->entite = new \mock\App\Components\Utilisateur\Entite();
     }
 
     /*************************************************

--- a/Tests/Units/App/Components/Planning/Controller.php
+++ b/Tests/Units/App/Components/Planning/Controller.php
@@ -19,7 +19,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     private $repository;
 
     /**
-     * @var \mock\App\Components\Planning\Entite Mock du modèle associé
+     * @var \mock\App\Components\Planning\Entite Mock de l'entité associée
      */
     private $entite;
 

--- a/Tests/Units/App/Components/Planning/Controller.php
+++ b/Tests/Units/App/Components/Planning/Controller.php
@@ -1,4 +1,4 @@
-<?php
+entite<?php
 namespace Tests\Units\App\Components\Planning;
 
 use \App\Components\Planning\Controller as _Controller;
@@ -21,7 +21,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     /**
      * @var \mock\App\Components\Planning\Model Mock du modèle associé
      */
-    private $model;
+    private $entite;
 
     /**
      * Init des tests
@@ -33,10 +33,10 @@ final class Controller extends \Tests\Units\App\Libraries\AController
         $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\App\Components\Planning\Repository();
         $this->mockGenerator->orphanize('__construct');
-        $this->model = new \mock\App\Components\Planning\Model();
-        $this->model->getMockController()->getId = 42;
-        $this->model->getMockController()->getName = 12;
-        $this->model->getMockController()->getStatus = 12;
+        $this->entite = new \mock\App\Components\Planning\Model();
+        $this->entite->getMockController()->getId = 42;
+        $this->entite->getMockController()->getName = 12;
+        $this->entite->getMockController()->getStatus = 12;
     }
 
     /*************************************************
@@ -48,7 +48,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
      */
     public function testGetOneFound()
     {
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
         $controller = new _Controller($this->repository, $this->router);
 
         $response = $controller->get($this->request, $this->response, ['planningId' => 99]);
@@ -100,7 +100,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     {
         $this->request->getMockController()->getQueryParams = [];
         $this->repository->getMockController()->getList = [
-            42 => $this->model,
+            42 => $this->entite,
         ];
         $controller = new _Controller($this->repository, $this->router);
 
@@ -293,7 +293,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testPutMissingRequiredArg()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
 
         $this->repository->getMockController()->putOne = function () {
             throw new \App\Exceptions\MissingArgumentException('');
@@ -311,7 +311,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testPutBadDomain()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \DomainException('');
         };
@@ -328,7 +328,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testPutPutOneFallback()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \LogicException('');
         };
@@ -345,7 +345,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testPutOk()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = '';
         $controller = new _Controller($this->repository, $this->router);
 
@@ -401,7 +401,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
      */
     public function testDeleteOk()
     {
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
         $controller = new _Controller($this->repository, $this->router);
 
         $response = $controller->delete($this->request, $this->response, ['planningId' => 99]);

--- a/Tests/Units/App/Components/Planning/Controller.php
+++ b/Tests/Units/App/Components/Planning/Controller.php
@@ -1,4 +1,4 @@
-entite<?php
+<?php
 namespace Tests\Units\App\Components\Planning;
 
 use \App\Components\Planning\Controller as _Controller;
@@ -19,7 +19,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     private $repository;
 
     /**
-     * @var \mock\App\Components\Planning\Model Mock du modèle associé
+     * @var \mock\App\Components\Planning\Entite Mock du modèle associé
      */
     private $entite;
 
@@ -33,7 +33,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
         $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\App\Components\Planning\Repository();
         $this->mockGenerator->orphanize('__construct');
-        $this->entite = new \mock\App\Components\Planning\Model();
+        $this->entite = new \mock\App\Components\Planning\Entite();
         $this->entite->getMockController()->getId = 42;
         $this->entite->getMockController()->getName = 12;
         $this->entite->getMockController()->getStatus = 12;

--- a/Tests/Units/App/Components/Planning/Creneau/Controller.php
+++ b/Tests/Units/App/Components/Planning/Creneau/Controller.php
@@ -19,7 +19,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     private $repository;
 
     /**
-     * @var \mock\App\Components\Planning\Creneau\Model Mock du modèle associé
+     * @var \mock\App\Components\Planning\Creneau\Entite Mock du modèle associé
      */
     private $entite;
 
@@ -32,7 +32,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
         $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\App\Components\Planning\Creneau\Repository();
         $this->mockGenerator->orphanize('__construct');
-        $this->entite = new \mock\App\Components\Planning\Creneau\Model();
+        $this->entite = new \mock\App\Components\Planning\Creneau\Entite();
         $this->entite->getMockController()->getId = 42;
         $this->entite->getMockController()->getPlanningId = 12;
         $this->entite->getMockController()->getJourId = 12;

--- a/Tests/Units/App/Components/Planning/Creneau/Controller.php
+++ b/Tests/Units/App/Components/Planning/Creneau/Controller.php
@@ -21,7 +21,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     /**
      * @var \mock\App\Components\Planning\Creneau\Model Mock du modèle associé
      */
-    private $model;
+    private $entite;
 
     /**
      * Init des tests
@@ -32,14 +32,14 @@ final class Controller extends \Tests\Units\App\Libraries\AController
         $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\App\Components\Planning\Creneau\Repository();
         $this->mockGenerator->orphanize('__construct');
-        $this->model = new \mock\App\Components\Planning\Creneau\Model();
-        $this->model->getMockController()->getId = 42;
-        $this->model->getMockController()->getPlanningId = 12;
-        $this->model->getMockController()->getJourId = 12;
-        $this->model->getMockController()->getTypeSemaine = 12;
-        $this->model->getMockController()->getTypePeriode = 12;
-        $this->model->getMockController()->getDebut = 12;
-        $this->model->getMockController()->getFin = 12;
+        $this->entite = new \mock\App\Components\Planning\Creneau\Model();
+        $this->entite->getMockController()->getId = 42;
+        $this->entite->getMockController()->getPlanningId = 12;
+        $this->entite->getMockController()->getJourId = 12;
+        $this->entite->getMockController()->getTypeSemaine = 12;
+        $this->entite->getMockController()->getTypePeriode = 12;
+        $this->entite->getMockController()->getDebut = 12;
+        $this->entite->getMockController()->getFin = 12;
     }
 
     /*************************************************
@@ -51,7 +51,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
      */
     public function testGetOneFound()
     {
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
         $controller = new _Controller($this->repository, $this->router);
 
         $response = $controller->get($this->request, $this->response, ['creneauId' => 99, 'planningId' => 45]);
@@ -102,7 +102,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testGetListFound()
     {
         $this->repository->getMockController()->getList = [
-            42 => $this->model,
+            42 => $this->entite,
         ];
         $controller = new _Controller($this->repository, $this->router);
 
@@ -295,7 +295,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testPutMissingRequiredArg()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
 
         $this->repository->getMockController()->putOne = function () {
             throw new \App\Exceptions\MissingArgumentException('');
@@ -313,7 +313,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testPutBadDomain()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \DomainException('');
         };
@@ -330,7 +330,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testPutPutOneFallback()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \LogicException('');
         };
@@ -347,7 +347,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     public function testPutOk()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->model;
+        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = '';
         $controller = new _Controller($this->repository, $this->router);
 

--- a/Tests/Units/App/Components/Planning/Creneau/Controller.php
+++ b/Tests/Units/App/Components/Planning/Creneau/Controller.php
@@ -19,7 +19,7 @@ final class Controller extends \Tests\Units\App\Libraries\AController
     private $repository;
 
     /**
-     * @var \mock\App\Components\Planning\Creneau\Entite Mock du modèle associé
+     * @var \mock\App\Components\Planning\Creneau\Entite Mock de l'entité associée
      */
     private $entite;
 

--- a/Tests/Units/App/Components/Planning/Creneau/Entite.php
+++ b/Tests/Units/App/Components/Planning/Creneau/Entite.php
@@ -4,7 +4,7 @@ namespace Tests\Units\App\Components\Planning\Creneau;
 use \App\Components\Planning\Creneau\Entite as _Entite;
 
 /**
- * Classe de test du modèle de créneau
+ * Classe de test de l'entité de créneau
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina

--- a/Tests/Units/App/Components/Planning/Creneau/Model.php
+++ b/Tests/Units/App/Components/Planning/Creneau/Model.php
@@ -21,10 +21,10 @@ final class Model extends \Tests\Units\App\Libraries\AModel
         $id = 3;
         $planning = 12;
 
-        $model = new _Model(['id' => $id, 'planningId' => $planning]);
+        $entite = new _Model(['id' => $id, 'planningId' => $planning]);
 
-        $this->assertConstructWithId($model, $id);
-        $this->integer($model->getPlanningId())->isIdenticalTo($planning);
+        $this->assertConstructWithId($entite, $id);
+        $this->integer($entite->getPlanningId())->isIdenticalTo($planning);
     }
 
     /**
@@ -32,9 +32,9 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testConstructWithoutId()
     {
-        $model = new _Model(['planningId' => 34]);
+        $entite = new _Model(['planningId' => 34]);
 
-        $this->variable($model->getId())->isNull();
+        $this->variable($entite->getId())->isNull();
     }
 
     /**
@@ -42,7 +42,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateBadDomain()
     {
-        $model = new _Model([]);
+        $entite = new _Model([]);
         $data = [
             'planningId' => '',
             'typeSemaine' => '',
@@ -52,8 +52,8 @@ final class Model extends \Tests\Units\App\Libraries\AModel
             'fin' => ''
         ];
 
-        $this->exception(function () use ($model, $data) {
-            $model->populate($data);
+        $this->exception(function () use ($entite, $data) {
+            $entite->populate($data);
         })->isInstanceOf('\DomainException');
     }
 
@@ -62,7 +62,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateOk()
     {
-        $model = new _Model([]);
+        $entite = new _Model([]);
         $data = [
             'planningId' => 12,
             'typeSemaine' => 23,
@@ -72,14 +72,14 @@ final class Model extends \Tests\Units\App\Libraries\AModel
             'fin' => 67,
         ];
 
-        $model->populate($data);
+        $entite->populate($data);
 
-        $this->integer($model->getPlanningId())->isIdenticalTo($data['planningId']);
-        $this->integer($model->getTypeSemaine())->isIdenticalTo($data['typeSemaine']);
-        $this->integer($model->getTypePeriode())->isIdenticalTo($data['typePeriode']);
-        $this->integer($model->getJourId())->isIdenticalTo($data['jourId']);
-        $this->integer($model->getDebut())->isIdenticalTo($data['debut']);
-        $this->integer($model->getFin())->isIdenticalTo($data['fin']);
+        $this->integer($entite->getPlanningId())->isIdenticalTo($data['planningId']);
+        $this->integer($entite->getTypeSemaine())->isIdenticalTo($data['typeSemaine']);
+        $this->integer($entite->getTypePeriode())->isIdenticalTo($data['typePeriode']);
+        $this->integer($entite->getJourId())->isIdenticalTo($data['jourId']);
+        $this->integer($entite->getDebut())->isIdenticalTo($data['debut']);
+        $this->integer($entite->getFin())->isIdenticalTo($data['fin']);
     }
 
     /**
@@ -87,9 +87,9 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testReset()
     {
-        $model = new _Model(['id' => 39, 'planningId' => 'test']);
+        $entite = new _Model(['id' => 39, 'planningId' => 'test']);
 
-        $this->assertReset($model);
+        $this->assertReset($entite);
     }
 
 }

--- a/Tests/Units/App/Components/Planning/Creneau/Model.php
+++ b/Tests/Units/App/Components/Planning/Creneau/Model.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tests\Units\App\Components\Planning\Creneau;
 
-use \App\Components\Planning\Creneau\Model as _Model;
+use \App\Components\Planning\Creneau\Entite as _Entite;
 
 /**
  * Classe de test du modèle de créneau
@@ -11,7 +11,7 @@ use \App\Components\Planning\Creneau\Model as _Model;
  *
  * @since 0.1
  */
-final class Model extends \Tests\Units\App\Libraries\AModel
+final class Entite extends \Tests\Units\App\Libraries\AEntite
 {
     /**
      * @inheritDoc
@@ -21,7 +21,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
         $id = 3;
         $planning = 12;
 
-        $entite = new _Model(['id' => $id, 'planningId' => $planning]);
+        $entite = new _Entite(['id' => $id, 'planningId' => $planning]);
 
         $this->assertConstructWithId($entite, $id);
         $this->integer($entite->getPlanningId())->isIdenticalTo($planning);
@@ -32,7 +32,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testConstructWithoutId()
     {
-        $entite = new _Model(['planningId' => 34]);
+        $entite = new _Entite(['planningId' => 34]);
 
         $this->variable($entite->getId())->isNull();
     }
@@ -42,7 +42,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateBadDomain()
     {
-        $entite = new _Model([]);
+        $entite = new _Entite([]);
         $data = [
             'planningId' => '',
             'typeSemaine' => '',
@@ -62,7 +62,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateOk()
     {
-        $entite = new _Model([]);
+        $entite = new _Entite([]);
         $data = [
             'planningId' => 12,
             'typeSemaine' => 23,
@@ -87,7 +87,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testReset()
     {
-        $entite = new _Model(['id' => 39, 'planningId' => 'test']);
+        $entite = new _Entite(['id' => 39, 'planningId' => 'test']);
 
         $this->assertReset($entite);
     }

--- a/Tests/Units/App/Components/Planning/Creneau/Repository.php
+++ b/Tests/Units/App/Components/Planning/Creneau/Repository.php
@@ -19,7 +19,7 @@ final class Repository extends \Atoum
     private $dao;
 
     /**
-     * @var \mock\App\Components\Planning\Creneau\Model Mock du Modèle de créneau
+     * @var \mock\App\Components\Planning\Creneau\Entite Mock du Modèle de créneau
      */
     private $entite;
 
@@ -29,7 +29,7 @@ final class Repository extends \Atoum
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\App\Components\Planning\Creneau\Dao();
         $this->mockGenerator->orphanize('__construct');
-        $this->entite = new \mock\App\Components\Planning\Creneau\Model();
+        $this->entite = new \mock\App\Components\Planning\Creneau\Entite();
         $this->entite->getMockController()->getId = 42;
     }
 
@@ -68,7 +68,7 @@ final class Repository extends \Atoum
 
         $entite = $repository->getOne(42, 23);
 
-        $this->object($entite)->isInstanceOf('\App\Libraries\AModel');
+        $this->object($entite)->isInstanceOf('\App\Libraries\AEntite');
         $this->integer($entite->getId())->isIdenticalTo(42);
     }
 
@@ -104,7 +104,7 @@ final class Repository extends \Atoum
         $entites = $repository->getList(['planningId' => 53]);
 
         $this->array($entites)->hasKey(42);
-        $this->object($entites[42])->isInstanceOf('\App\Libraries\AModel');
+        $this->object($entites[42])->isInstanceOf('\App\Libraries\AEntite');
     }
 
     /*************************************************
@@ -117,7 +117,7 @@ final class Repository extends \Atoum
     public function testPostListException()
     {
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite = new \mock\App\Components\Planning\Creneau\Entite([]);
         $entite->getMockController()->populate = function () {
             throw new \LogicException('');
         };
@@ -141,7 +141,7 @@ final class Repository extends \Atoum
     public function testPostListOk()
     {
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite = new \mock\App\Components\Planning\Creneau\Entite([]);
         $entite->getMockController()->populate = '';
         $entite->getMockController()->getPlanningId = 3;
         $entite->getMockController()->getJourId = 4;
@@ -176,7 +176,7 @@ final class Repository extends \Atoum
     public function testPostOneMissingArgument()
     {
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite = new \mock\App\Components\Planning\Creneau\Entite([]);
 
         $this->exception(function () use ($repository, $entite) {
             $repository->postOne([], $entite);
@@ -189,7 +189,7 @@ final class Repository extends \Atoum
     public function testPostOneBadDomain()
     {
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite = new \mock\App\Components\Planning\Creneau\Entite([]);
         $entite->getMockController()->populate = function () {
             throw new \DomainException('');
         };
@@ -213,7 +213,7 @@ final class Repository extends \Atoum
     public function testPostOneOk()
     {
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite = new \mock\App\Components\Planning\Creneau\Entite([]);
         $entite->getMockController()->populate = '';
         $entite->getMockController()->getPlanningId = 3;
         $entite->getMockController()->getJourId = 4;
@@ -248,7 +248,7 @@ final class Repository extends \Atoum
         $repository = new _Repository($this->dao);
 
         $this->exception(function () use ($repository) {
-            $repository->putOne(['planningId' => 4], new \mock\App\Components\Planning\Creneau\Model([]));
+            $repository->putOne(['planningId' => 4], new \mock\App\Components\Planning\Creneau\Entite([]));
         })->isInstanceOf('\App\Exceptions\MissingArgumentException');
     }
 
@@ -258,7 +258,7 @@ final class Repository extends \Atoum
     public function testPutOneBadDomain()
     {
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite = new \mock\App\Components\Planning\Creneau\Entite([]);
         $entite->getMockController()->populate = function () {
             throw new \DomainException('');
         };

--- a/Tests/Units/App/Components/Planning/Creneau/Repository.php
+++ b/Tests/Units/App/Components/Planning/Creneau/Repository.php
@@ -21,7 +21,7 @@ final class Repository extends \Atoum
     /**
      * @var \mock\App\Components\Planning\Creneau\Model Mock du Modèle de créneau
      */
-    private $model;
+    private $entite;
 
     public function beforeTestMethod($method)
     {
@@ -29,8 +29,8 @@ final class Repository extends \Atoum
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\App\Components\Planning\Creneau\Dao();
         $this->mockGenerator->orphanize('__construct');
-        $this->model = new \mock\App\Components\Planning\Creneau\Model();
-        $this->model->getMockController()->getId = 42;
+        $this->entite = new \mock\App\Components\Planning\Creneau\Model();
+        $this->entite->getMockController()->getId = 42;
     }
 
     /*************************************************
@@ -66,10 +66,10 @@ final class Repository extends \Atoum
         ];
         $repository = new _Repository($this->dao);
 
-        $model = $repository->getOne(42, 23);
+        $entite = $repository->getOne(42, 23);
 
-        $this->object($model)->isInstanceOf('\App\Libraries\AModel');
-        $this->integer($model->getId())->isIdenticalTo(42);
+        $this->object($entite)->isInstanceOf('\App\Libraries\AModel');
+        $this->integer($entite->getId())->isIdenticalTo(42);
     }
 
     /**
@@ -101,10 +101,10 @@ final class Repository extends \Atoum
         ]];
         $repository = new _Repository($this->dao);
 
-        $models = $repository->getList(['planningId' => 53]);
+        $entites = $repository->getList(['planningId' => 53]);
 
-        $this->array($models)->hasKey(42);
-        $this->object($models[42])->isInstanceOf('\App\Libraries\AModel');
+        $this->array($entites)->hasKey(42);
+        $this->object($entites[42])->isInstanceOf('\App\Libraries\AModel');
     }
 
     /*************************************************
@@ -117,8 +117,8 @@ final class Repository extends \Atoum
     public function testPostListException()
     {
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Creneau\Model([]);
-        $model->getMockController()->populate = function () {
+        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite->getMockController()->populate = function () {
             throw new \LogicException('');
         };
         $data = [
@@ -130,8 +130,8 @@ final class Repository extends \Atoum
             'fin' => 92,
         ];
 
-        $this->exception(function () use ($repository, $data, $model) {
-            $repository->postList([$data], $model);
+        $this->exception(function () use ($repository, $data, $entite) {
+            $repository->postList([$data], $entite);
         })->isInstanceOf('\LogicException');
     }
 
@@ -141,14 +141,14 @@ final class Repository extends \Atoum
     public function testPostListOk()
     {
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Creneau\Model([]);
-        $model->getMockController()->populate = '';
-        $model->getMockController()->getPlanningId = 3;
-        $model->getMockController()->getJourId = 4;
-        $model->getMockController()->getTypeSemaine = 5;
-        $model->getMockController()->getTypePeriode = 6;
-        $model->getMockController()->getDebut = 7;
-        $model->getMockController()->getFin = 8;
+        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite->getMockController()->populate = '';
+        $entite->getMockController()->getPlanningId = 3;
+        $entite->getMockController()->getJourId = 4;
+        $entite->getMockController()->getTypeSemaine = 5;
+        $entite->getMockController()->getTypePeriode = 6;
+        $entite->getMockController()->getDebut = 7;
+        $entite->getMockController()->getFin = 8;
         $data = [
             [
                 'planningId' => 34,
@@ -163,7 +163,7 @@ final class Repository extends \Atoum
         $this->dao->getMockController()->post[2] = 9;
 
 
-        $post = $repository->postList($data, $model);
+        $post = $repository->postList($data, $entite);
 
         foreach ($post as $postId) {
             $this->integer($postId);
@@ -176,10 +176,10 @@ final class Repository extends \Atoum
     public function testPostOneMissingArgument()
     {
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
 
-        $this->exception(function () use ($repository, $model) {
-            $repository->postOne([], $model);
+        $this->exception(function () use ($repository, $entite) {
+            $repository->postOne([], $entite);
         })->isInstanceOf('\App\Exceptions\MissingArgumentException');
     }
 
@@ -189,8 +189,8 @@ final class Repository extends \Atoum
     public function testPostOneBadDomain()
     {
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Creneau\Model([]);
-        $model->getMockController()->populate = function () {
+        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite->getMockController()->populate = function () {
             throw new \DomainException('');
         };
         $data = [
@@ -202,8 +202,8 @@ final class Repository extends \Atoum
             'fin' => 92,
         ];
 
-        $this->exception(function () use ($repository, $data, $model) {
-            $repository->postOne($data, $model);
+        $this->exception(function () use ($repository, $data, $entite) {
+            $repository->postOne($data, $entite);
         })->isInstanceOf('\DomainException');
     }
 
@@ -213,14 +213,14 @@ final class Repository extends \Atoum
     public function testPostOneOk()
     {
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Creneau\Model([]);
-        $model->getMockController()->populate = '';
-        $model->getMockController()->getPlanningId = 3;
-        $model->getMockController()->getJourId = 4;
-        $model->getMockController()->getTypeSemaine = 5;
-        $model->getMockController()->getTypePeriode = 6;
-        $model->getMockController()->getDebut = 7;
-        $model->getMockController()->getFin = 8;
+        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite->getMockController()->populate = '';
+        $entite->getMockController()->getPlanningId = 3;
+        $entite->getMockController()->getJourId = 4;
+        $entite->getMockController()->getTypeSemaine = 5;
+        $entite->getMockController()->getTypePeriode = 6;
+        $entite->getMockController()->getDebut = 7;
+        $entite->getMockController()->getFin = 8;
         $data = [
             'planningId' => 34,
             'jourId' => 2,
@@ -231,7 +231,7 @@ final class Repository extends \Atoum
         ];
         $this->dao->getMockController()->post = 3;
 
-        $post = $repository->postOne($data, $model);
+        $post = $repository->postOne($data, $entite);
 
         $this->integer($post);
     }
@@ -258,12 +258,12 @@ final class Repository extends \Atoum
     public function testPutOneBadDomain()
     {
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Creneau\Model([]);
-        $model->getMockController()->populate = function () {
+        $entite = new \mock\App\Components\Planning\Creneau\Model([]);
+        $entite->getMockController()->populate = function () {
             throw new \DomainException('');
         };
 
-        $this->exception(function () use ($repository, $model) {
+        $this->exception(function () use ($repository, $entite) {
             $repository->putOne(
                 [
                     'planningId' => 4,
@@ -273,7 +273,7 @@ final class Repository extends \Atoum
                     'debut' => 3,
                     'fin' => 129,
                 ],
-                $model);
+                $entite);
         })->isInstanceOf('\DomainException');
     }
 
@@ -293,7 +293,7 @@ final class Repository extends \Atoum
                 'debut' => 37,
                 'fin' => 129,
             ],
-            $this->model);
+            $this->entite);
 
         $this->variable($result)->isNull();
     }

--- a/Tests/Units/App/Components/Planning/Creneau/Repository.php
+++ b/Tests/Units/App/Components/Planning/Creneau/Repository.php
@@ -19,7 +19,7 @@ final class Repository extends \Atoum
     private $dao;
 
     /**
-     * @var \mock\App\Components\Planning\Creneau\Entite Mock du Modèle de créneau
+     * @var \mock\App\Components\Planning\Creneau\Entite Mock de l'Entité de créneau
      */
     private $entite;
 

--- a/Tests/Units/App/Components/Planning/Entite.php
+++ b/Tests/Units/App/Components/Planning/Entite.php
@@ -4,7 +4,7 @@ namespace Tests\Units\App\Components\Planning;
 use \App\Components\Planning\Entite as _Entite;
 
 /**
- * Classe de test du modèle de planning
+ * Classe de test de l'entité de planning
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina

--- a/Tests/Units/App/Components/Planning/Model.php
+++ b/Tests/Units/App/Components/Planning/Model.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tests\Units\App\Components\Planning;
 
-use \App\Components\Planning\Model as _Model;
+use \App\Components\Planning\Entite as _Entite;
 
 /**
  * Classe de test du modèle de planning
@@ -11,7 +11,7 @@ use \App\Components\Planning\Model as _Model;
  *
  * @since 0.1
  */
-final class Model extends \Tests\Units\App\Libraries\AModel
+final class Entite extends \Tests\Units\App\Libraries\AEntite
 {
     /**
      * @inheritDoc
@@ -22,7 +22,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
         $name = 'name';
         $status = 4;
 
-        $entite = new _Model(['id' => $id, 'name' => 'name', 'status' => $status]);
+        $entite = new _Entite(['id' => $id, 'name' => 'name', 'status' => $status]);
 
         $this->assertConstructWithId($entite, $id);
         $this->string($entite->getName())->isIdenticalTo($name);
@@ -34,7 +34,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testConstructWithoutId()
     {
-        $entite = new _Model(['name' => 'name', 'status' => 'status']);
+        $entite = new _Entite(['name' => 'name', 'status' => 'status']);
 
         $this->variable($entite->getId())->isNull();
     }
@@ -44,7 +44,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateBadDomain()
     {
-        $entite = new _Model([]);
+        $entite = new _Entite([]);
         $data = ['name' => '', 'status' => 45];
 
         $this->exception(function () use ($entite, $data) {
@@ -57,7 +57,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateOk()
     {
-        $entite = new _Model([]);
+        $entite = new _Entite([]);
         $data = ['name' => 'test', 'status' => 48];
 
         $entite->populate($data);
@@ -71,7 +71,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testReset()
     {
-        $entite = new _Model(['id' => 3, 'name' => 'name', 'status' => 'status']);
+        $entite = new _Entite(['id' => 3, 'name' => 'name', 'status' => 'status']);
 
         $this->assertReset($entite);
     }

--- a/Tests/Units/App/Components/Planning/Model.php
+++ b/Tests/Units/App/Components/Planning/Model.php
@@ -22,11 +22,11 @@ final class Model extends \Tests\Units\App\Libraries\AModel
         $name = 'name';
         $status = 4;
 
-        $model = new _Model(['id' => $id, 'name' => 'name', 'status' => $status]);
+        $entite = new _Model(['id' => $id, 'name' => 'name', 'status' => $status]);
 
-        $this->assertConstructWithId($model, $id);
-        $this->string($model->getName())->isIdenticalTo($name);
-        $this->integer($model->getStatus())->isIdenticalTo($status);
+        $this->assertConstructWithId($entite, $id);
+        $this->string($entite->getName())->isIdenticalTo($name);
+        $this->integer($entite->getStatus())->isIdenticalTo($status);
     }
 
     /**
@@ -34,9 +34,9 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testConstructWithoutId()
     {
-        $model = new _Model(['name' => 'name', 'status' => 'status']);
+        $entite = new _Model(['name' => 'name', 'status' => 'status']);
 
-        $this->variable($model->getId())->isNull();
+        $this->variable($entite->getId())->isNull();
     }
 
     /**
@@ -44,11 +44,11 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateBadDomain()
     {
-        $model = new _Model([]);
+        $entite = new _Model([]);
         $data = ['name' => '', 'status' => 45];
 
-        $this->exception(function () use ($model, $data) {
-            $model->populate($data);
+        $this->exception(function () use ($entite, $data) {
+            $entite->populate($data);
         })->isInstanceOf('\DomainException');
     }
 
@@ -57,13 +57,13 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateOk()
     {
-        $model = new _Model([]);
+        $entite = new _Model([]);
         $data = ['name' => 'test', 'status' => 48];
 
-        $model->populate($data);
+        $entite->populate($data);
 
-        $this->string($model->getName())->isIdenticalTo($data['name']);
-        $this->integer($model->getStatus())->isIdenticalTo($data['status']);
+        $this->string($entite->getName())->isIdenticalTo($data['name']);
+        $this->integer($entite->getStatus())->isIdenticalTo($data['status']);
     }
 
     /**
@@ -71,8 +71,8 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testReset()
     {
-        $model = new _Model(['id' => 3, 'name' => 'name', 'status' => 'status']);
+        $entite = new _Model(['id' => 3, 'name' => 'name', 'status' => 'status']);
 
-        $this->assertReset($model);
+        $this->assertReset($entite);
     }
 }

--- a/Tests/Units/App/Components/Planning/Repository.php
+++ b/Tests/Units/App/Components/Planning/Repository.php
@@ -21,7 +21,7 @@ final class Repository extends \Atoum
     /**
      * @var \mock\App\Components\Planning\Model Mock du Modèle de planning
      */
-    private $model;
+    private $entite;
 
     public function beforeTestMethod($method)
     {
@@ -29,10 +29,10 @@ final class Repository extends \Atoum
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\App\Components\Planning\Dao();
         $this->mockGenerator->orphanize('__construct');
-        $this->model = new \mock\App\Components\Planning\Model();
-        $this->model->getMockController()->getId = 42;
-        $this->model->getMockController()->getName = 12;
-        $this->model->getMockController()->getStatus = 12;
+        $this->entite = new \mock\App\Components\Planning\Model();
+        $this->entite->getMockController()->getId = 42;
+        $this->entite->getMockController()->getName = 12;
+        $this->entite->getMockController()->getStatus = 12;
     }
 
     /*************************************************
@@ -64,10 +64,10 @@ final class Repository extends \Atoum
         ];
         $repository = new _Repository($this->dao);
 
-        $model = $repository->getOne(42);
+        $entite = $repository->getOne(42);
 
-        $this->object($model)->isInstanceOf('\App\Libraries\AModel');
-        $this->integer($model->getId())->isIdenticalTo(42);
+        $this->object($entite)->isInstanceOf('\App\Libraries\AModel');
+        $this->integer($entite->getId())->isIdenticalTo(42);
     }
 
     /**
@@ -95,10 +95,10 @@ final class Repository extends \Atoum
         ]];
         $repository = new _Repository($this->dao);
 
-        $models = $repository->getList([]);
+        $entites = $repository->getList([]);
 
-        $this->array($models)->hasKey(42);
-        $this->object($models[42])->isInstanceOf('\App\Libraries\AModel');
+        $this->array($entites)->hasKey(42);
+        $this->object($entites[42])->isInstanceOf('\App\Libraries\AModel');
     }
 
     /*************************************************
@@ -123,13 +123,13 @@ final class Repository extends \Atoum
     public function testPostOneBadDomain()
     {
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Model([]);
-        $model->getMockController()->populate = function () {
+        $entite = new \mock\App\Components\Planning\Model([]);
+        $entite->getMockController()->populate = function () {
             throw new \DomainException('');
         };
 
-        $this->exception(function () use ($repository, $model) {
-            $repository->postOne(['name' => 'bob', 'status' => 'bab'], $model);
+        $this->exception(function () use ($repository, $entite) {
+            $repository->postOne(['name' => 'bob', 'status' => 'bab'], $entite);
         })->isInstanceOf('\DomainException');
     }
 
@@ -139,13 +139,13 @@ final class Repository extends \Atoum
     public function testPostOneOk()
     {
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Model([]);
-        $model->getMockController()->populate = '';
-        $model->getMockController()->getName = 'name';
-        $model->getMockController()->getStatus = 'status';
+        $entite = new \mock\App\Components\Planning\Model([]);
+        $entite->getMockController()->populate = '';
+        $entite->getMockController()->getName = 'name';
+        $entite->getMockController()->getStatus = 'status';
         $this->dao->getMockController()->post = 3;
 
-        $post = $repository->postOne(['name' => 'bob', 'status' => 'pop'], $model);
+        $post = $repository->postOne(['name' => 'bob', 'status' => 'pop'], $entite);
 
         $this->integer($post);
     }
@@ -172,13 +172,13 @@ final class Repository extends \Atoum
     public function testPutOneBadDomain()
     {
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Model([]);
-        $model->getMockController()->populate = function () {
+        $entite = new \mock\App\Components\Planning\Model([]);
+        $entite->getMockController()->populate = function () {
             throw new \DomainException('');
         };
 
-        $this->exception(function () use ($repository, $model) {
-            $repository->putOne(['name' => 'bob', 'status' => 'bab'], $model);
+        $this->exception(function () use ($repository, $entite) {
+            $repository->putOne(['name' => 'bob', 'status' => 'bab'], $entite);
         })->isInstanceOf('\DomainException');
     }
 
@@ -189,7 +189,7 @@ final class Repository extends \Atoum
     {
         $repository = new _Repository($this->dao);
 
-        $result = $repository->putOne(['name' => 'baba', 'status' => 4], $this->model);
+        $result = $repository->putOne(['name' => 'baba', 'status' => 4], $this->entite);
 
         $this->variable($result)->isNull();
     }
@@ -221,8 +221,8 @@ final class Repository extends \Atoum
     {
         $this->dao->getMockController()->delete = 4;
         $repository = new _Repository($this->dao);
-        $model = new \mock\App\Components\Planning\Model([]);
+        $entite = new \mock\App\Components\Planning\Model([]);
 
-        $this->variable($repository->deleteOne($model))->isNull();
+        $this->variable($repository->deleteOne($entite))->isNull();
     }
 }

--- a/Tests/Units/App/Components/Planning/Repository.php
+++ b/Tests/Units/App/Components/Planning/Repository.php
@@ -19,7 +19,7 @@ final class Repository extends \Atoum
     private $dao;
 
     /**
-     * @var \mock\App\Components\Planning\Model Mock du Modèle de planning
+     * @var \mock\App\Components\Planning\Entite Mock du Modèle de planning
      */
     private $entite;
 
@@ -29,7 +29,7 @@ final class Repository extends \Atoum
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\App\Components\Planning\Dao();
         $this->mockGenerator->orphanize('__construct');
-        $this->entite = new \mock\App\Components\Planning\Model();
+        $this->entite = new \mock\App\Components\Planning\Entite();
         $this->entite->getMockController()->getId = 42;
         $this->entite->getMockController()->getName = 12;
         $this->entite->getMockController()->getStatus = 12;
@@ -66,7 +66,7 @@ final class Repository extends \Atoum
 
         $entite = $repository->getOne(42);
 
-        $this->object($entite)->isInstanceOf('\App\Libraries\AModel');
+        $this->object($entite)->isInstanceOf('\App\Libraries\AEntite');
         $this->integer($entite->getId())->isIdenticalTo(42);
     }
 
@@ -98,7 +98,7 @@ final class Repository extends \Atoum
         $entites = $repository->getList([]);
 
         $this->array($entites)->hasKey(42);
-        $this->object($entites[42])->isInstanceOf('\App\Libraries\AModel');
+        $this->object($entites[42])->isInstanceOf('\App\Libraries\AEntite');
     }
 
     /*************************************************
@@ -113,7 +113,7 @@ final class Repository extends \Atoum
         $repository = new _Repository($this->dao);
 
         $this->exception(function () use ($repository) {
-            $repository->postOne(['name' => 'bob'], new \mock\App\Components\Planning\Model([]));
+            $repository->postOne(['name' => 'bob'], new \mock\App\Components\Planning\Entite([]));
         })->isInstanceOf('\App\Exceptions\MissingArgumentException');
     }
 
@@ -123,7 +123,7 @@ final class Repository extends \Atoum
     public function testPostOneBadDomain()
     {
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Model([]);
+        $entite = new \mock\App\Components\Planning\Entite([]);
         $entite->getMockController()->populate = function () {
             throw new \DomainException('');
         };
@@ -139,7 +139,7 @@ final class Repository extends \Atoum
     public function testPostOneOk()
     {
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Model([]);
+        $entite = new \mock\App\Components\Planning\Entite([]);
         $entite->getMockController()->populate = '';
         $entite->getMockController()->getName = 'name';
         $entite->getMockController()->getStatus = 'status';
@@ -162,7 +162,7 @@ final class Repository extends \Atoum
         $repository = new _Repository($this->dao);
 
         $this->exception(function () use ($repository) {
-            $repository->putOne(['name' => 'bob'], new \mock\App\Components\Planning\Model([]));
+            $repository->putOne(['name' => 'bob'], new \mock\App\Components\Planning\Entite([]));
         })->isInstanceOf('\App\Exceptions\MissingArgumentException');
     }
 
@@ -172,7 +172,7 @@ final class Repository extends \Atoum
     public function testPutOneBadDomain()
     {
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Model([]);
+        $entite = new \mock\App\Components\Planning\Entite([]);
         $entite->getMockController()->populate = function () {
             throw new \DomainException('');
         };
@@ -209,7 +209,7 @@ final class Repository extends \Atoum
         $repository = new _Repository($this->dao);
 
         $this->exception(function () use ($repository) {
-            $repository->deleteOne(new \mock\App\Components\Planning\Model([]));
+            $repository->deleteOne(new \mock\App\Components\Planning\Entite([]));
         })->isInstanceOf('\LogicException');
 
     }
@@ -221,7 +221,7 @@ final class Repository extends \Atoum
     {
         $this->dao->getMockController()->delete = 4;
         $repository = new _Repository($this->dao);
-        $entite = new \mock\App\Components\Planning\Model([]);
+        $entite = new \mock\App\Components\Planning\Entite([]);
 
         $this->variable($repository->deleteOne($entite))->isNull();
     }

--- a/Tests/Units/App/Components/Planning/Repository.php
+++ b/Tests/Units/App/Components/Planning/Repository.php
@@ -19,7 +19,7 @@ final class Repository extends \Atoum
     private $dao;
 
     /**
-     * @var \mock\App\Components\Planning\Entite Mock du Modèle de planning
+     * @var \mock\App\Components\Planning\Entite Mock de l'Entité de planning
      */
     private $entite;
 

--- a/Tests/Units/App/Components/Utilisateur/Entite.php
+++ b/Tests/Units/App/Components/Utilisateur/Entite.php
@@ -4,7 +4,7 @@ namespace Tests\Units\App\Components\Utilisateur;
 use \App\Components\Utilisateur\Entite as _Entite;
 
 /**
- * Classe de test du modèle de l'utilisateur
+ * Classe de test de l'entité de l'utilisateur
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina

--- a/Tests/Units/App/Components/Utilisateur/Entite.php
+++ b/Tests/Units/App/Components/Utilisateur/Entite.php
@@ -40,9 +40,9 @@ final class Entite extends \Tests\Units\App\Libraries\AEntite
      */
     public function testGetLogin()
     {
-        $model = new _Model(['token' => 'token', 'login' => 'login']);
+        $entite = new _Entite(['token' => 'token', 'login' => 'login']);
 
-        $this->variable($model->getLogin())->isNull();
+        $this->variable($entite->getLogin())->isNull();
     }
 
     /**
@@ -84,12 +84,12 @@ final class Entite extends \Tests\Units\App\Libraries\AEntite
 
     public function testUpdateDateLastAccess()
     {
-        $model = new _Model(['id' => 3, 'dateLastAccess' => "0"]);
+        $entite = new _Entite(['id' => 3, 'dateLastAccess' => "0"]);
 
-        $this->string($model->getDateLastAccess())->isIdenticalTo("0");
+        $this->string($entite->getDateLastAccess())->isIdenticalTo("0");
 
-        $model->updateDateLastAccess();
+        $entite->updateDateLastAccess();
 
-        $this->string($model->getDateLastAccess())->isIdenticalTo(date('Y-m-d H:i'));
+        $this->string($entite->getDateLastAccess())->isIdenticalTo(date('Y-m-d H:i'));
     }
 }

--- a/Tests/Units/App/Components/Utilisateur/Model.php
+++ b/Tests/Units/App/Components/Utilisateur/Model.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tests\Units\App\Components\Utilisateur;
 
-use \App\Components\Utilisateur\Model as _Model;
+use \App\Components\Utilisateur\Entite as _Entite;
 
 /**
  * Classe de test du modèle de l'utilisateur
@@ -11,7 +11,7 @@ use \App\Components\Utilisateur\Model as _Model;
  *
  * @since 0.2
  */
-final class Model extends \Tests\Units\App\Libraries\AModel
+final class Entite extends \Tests\Units\App\Libraries\AEntite
 {
     /**
      * @inheritDoc
@@ -20,7 +20,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
     {
         $id = 'Balin';
 
-        $entite = new _Model(['id' => $id]);
+        $entite = new _Entite(['id' => $id]);
 
         $this->string($entite->getId())->isIdenticalTo($id);
     }
@@ -30,7 +30,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testConstructWithoutId()
     {
-        $entite = new _Model(['token' => 'token']);
+        $entite = new _Entite(['token' => 'token']);
 
         $this->variable($entite->getId())->isNull();
     }
@@ -50,7 +50,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testReset()
     {
-        $entite = new _Model(['id' => 'Balin', 'token' => 'token']);
+        $entite = new _Entite(['id' => 'Balin', 'token' => 'token']);
 
         $this->assertReset($entite);
     }
@@ -60,7 +60,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateTokenBadDomain()
     {
-        $entite = new _Model([]);
+        $entite = new _Entite([]);
         $token = '';
 
         $this->exception(function () use ($entite, $token) {
@@ -74,7 +74,7 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateTokenOk()
     {
-        $entite = new _Model([]);
+        $entite = new _Entite([]);
         $token = 'AZP3401GJE9#';
 
         $entite->populateToken($token);

--- a/Tests/Units/App/Components/Utilisateur/Model.php
+++ b/Tests/Units/App/Components/Utilisateur/Model.php
@@ -20,9 +20,9 @@ final class Model extends \Tests\Units\App\Libraries\AModel
     {
         $id = 'Balin';
 
-        $model = new _Model(['id' => $id]);
+        $entite = new _Model(['id' => $id]);
 
-        $this->string($model->getId())->isIdenticalTo($id);
+        $this->string($entite->getId())->isIdenticalTo($id);
     }
 
     /**
@@ -30,9 +30,9 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testConstructWithoutId()
     {
-        $model = new _Model(['token' => 'token']);
+        $entite = new _Model(['token' => 'token']);
 
-        $this->variable($model->getId())->isNull();
+        $this->variable($entite->getId())->isNull();
     }
 
     /**
@@ -50,9 +50,9 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testReset()
     {
-        $model = new _Model(['id' => 'Balin', 'token' => 'token']);
+        $entite = new _Model(['id' => 'Balin', 'token' => 'token']);
 
-        $this->assertReset($model);
+        $this->assertReset($entite);
     }
 
     /**
@@ -60,11 +60,11 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateTokenBadDomain()
     {
-        $model = new _Model([]);
+        $entite = new _Model([]);
         $token = '';
 
-        $this->exception(function () use ($model, $token) {
-            $model->populateToken($token);
+        $this->exception(function () use ($entite, $token) {
+            $entite->populateToken($token);
         })->isInstanceOf('\DomainException');
     }
 
@@ -74,12 +74,12 @@ final class Model extends \Tests\Units\App\Libraries\AModel
      */
     public function testPopulateTokenOk()
     {
-        $model = new _Model([]);
+        $entite = new _Model([]);
         $token = 'AZP3401GJE9#';
 
-        $model->populateToken($token);
+        $entite->populateToken($token);
 
-        $this->string($model->getToken())->isIdenticalTo($token);
+        $this->string($entite->getToken())->isIdenticalTo($token);
     }
 
     public function testUpdateDateLastAccess()

--- a/Tests/Units/App/Components/Utilisateur/Repository.php
+++ b/Tests/Units/App/Components/Utilisateur/Repository.php
@@ -1,4 +1,4 @@
-<?php
+entite<?php
 namespace Tests\Units\App\Components\Utilisateur;
 
 use \App\Components\Utilisateur\Repository as _Repository;
@@ -37,7 +37,7 @@ final class Repository extends \Atoum
     /**
      * @var \mock\App\Components\Utilisateur\Model Mock du Modèle de l'utilisateur
      */
-    private $model;
+    private $entite;
 
     public function beforeTestMethod($method)
     {
@@ -54,9 +54,9 @@ final class Repository extends \Atoum
         $this->connector->getMockController()->query = $this->statement;
         $this->application = new \mock\App\Libraries\Application($this->connector);
         $this->mockGenerator->orphanize('__construct');
-        $this->model = new \mock\App\Components\Utilisateur\Model();
-        $this->model->getMockController()->getNom = 'Aladdin';
-        $this->model->getMockController()->getDateInscription = '222';
+        $this->entite = new \mock\App\Components\Utilisateur\Model();
+        $this->entite->getMockController()->getNom = 'Aladdin';
+        $this->entite->getMockController()->getDateInscription = '222';
     }
 
     /**
@@ -142,9 +142,9 @@ final class Repository extends \Atoum
         ];
         $repository = new _Repository($this->dao);
 
-        $model = $repository->find([]);
+        $entite = $repository->find([]);
 
-        $this->object($model)->isInstanceOf('\App\Libraries\AModel');
+        $this->object($entite)->isInstanceOf('\App\Libraries\AModel');
     }
 
     /**
@@ -187,10 +187,10 @@ final class Repository extends \Atoum
         ]];
         $repository = new _Repository($this->dao);
 
-        $models = $repository->getList([]);
+        $entites = $repository->getList([]);
 
-        $this->array($models)->hasKey('Aladdin');
-        $this->object($models['Aladdin'])->isInstanceOf('\App\Libraries\AModel');
+        $this->array($entites)->hasKey('Aladdin');
+        $this->object($entites['Aladdin'])->isInstanceOf('\App\Libraries\AModel');
     }
 
     /*************************************************
@@ -200,7 +200,7 @@ final class Repository extends \Atoum
 
     public function testPostOne()
     {
-        $this->variable((new _Repository($this->dao))->postOne([], $this->model))->isNull();
+        $this->variable((new _Repository($this->dao))->postOne([], $this->entite))->isNull();
     }
 
     /*************************************************
@@ -209,7 +209,7 @@ final class Repository extends \Atoum
 
     public function testPutOne()
     {
-        $this->variable((new _Repository($this->dao))->putOne([], $this->model))->isNull();
+        $this->variable((new _Repository($this->dao))->putOne([], $this->entite))->isNull();
     }
 
     public function testUpdateDateLastAccess()
@@ -234,7 +234,7 @@ final class Repository extends \Atoum
         $repository->setApplication($this->application);
 
         $this->exception(function () use ($repository) {
-            $repository->regenerateToken($this->model);
+            $repository->regenerateToken($this->entite);
         })->isInstanceOf('\RuntimeException');
     }
 
@@ -246,12 +246,12 @@ final class Repository extends \Atoum
         $repository = new _Repository($this->dao);
         $this->application->getMockController()->getTokenInstance = 'vi veri veniversum vivus vici';
         $repository->setApplication($this->application);
-        $this->model->getMockController()->populateToken = function () {
+        $this->entite->getMockController()->populateToken = function () {
             throw new \DomainException('');
         };
 
         $this->exception(function () use ($repository) {
-            $repository->regenerateToken($this->model);
+            $repository->regenerateToken($this->entite);
         })->isInstanceOf('\DomainException');
     }
 
@@ -260,13 +260,13 @@ final class Repository extends \Atoum
         $repository = new _Repository($this->dao);
         $this->application->getMockController()->getTokenInstance = 'vi veri veniversum vivus vici';
         $repository->setApplication($this->application);
-        $this->model->getMockController()->populateToken = '';
-        $this->model->getMockController()->getToken = 'Pedro l\'asticot';
+        $this->entite->getMockController()->populateToken = '';
+        $this->entite->getMockController()->getToken = 'Pedro l\'asticot';
         $this->dao->getMockController()->put = '';
 
-        $model = $repository->regenerateToken($this->model);
+        $entite = $repository->regenerateToken($this->entite);
 
-        $this->object($model)->isInstanceOf(AModel::class);
+        $this->object($entite)->isInstanceOf(AModel::class);
     }
 
     /*************************************************
@@ -275,6 +275,6 @@ final class Repository extends \Atoum
 
     public function testDeleteOne()
     {
-        $this->variable((new _Repository($this->dao))->deleteOne($this->model))->isNull();
+        $this->variable((new _Repository($this->dao))->deleteOne($this->entite))->isNull();
     }
 }

--- a/Tests/Units/App/Components/Utilisateur/Repository.php
+++ b/Tests/Units/App/Components/Utilisateur/Repository.php
@@ -35,7 +35,7 @@ final class Repository extends \Atoum
     private $statement;
 
     /**
-     * @var \mock\App\Components\Utilisateur\Entite Mock du Modèle de l'utilisateur
+     * @var \mock\App\Components\Utilisateur\Entite Mock de l'Entité de l'utilisateur
      */
     private $entite;
 

--- a/Tests/Units/App/Components/Utilisateur/Repository.php
+++ b/Tests/Units/App/Components/Utilisateur/Repository.php
@@ -1,8 +1,8 @@
-entite<?php
+<?php
 namespace Tests\Units\App\Components\Utilisateur;
 
 use \App\Components\Utilisateur\Repository as _Repository;
-use App\Libraries\AModel;
+use App\Libraries\AEntite;
 
 /**
  * Classe de test du repository de l'utilisateur
@@ -35,7 +35,7 @@ final class Repository extends \Atoum
     private $statement;
 
     /**
-     * @var \mock\App\Components\Utilisateur\Model Mock du Modèle de l'utilisateur
+     * @var \mock\App\Components\Utilisateur\Entite Mock du Modèle de l'utilisateur
      */
     private $entite;
 
@@ -54,7 +54,7 @@ final class Repository extends \Atoum
         $this->connector->getMockController()->query = $this->statement;
         $this->application = new \mock\App\Libraries\Application($this->connector);
         $this->mockGenerator->orphanize('__construct');
-        $this->entite = new \mock\App\Components\Utilisateur\Model();
+        $this->entite = new \mock\App\Components\Utilisateur\Entite();
         $this->entite->getMockController()->getNom = 'Aladdin';
         $this->entite->getMockController()->getDateInscription = '222';
     }
@@ -144,7 +144,7 @@ final class Repository extends \Atoum
 
         $entite = $repository->find([]);
 
-        $this->object($entite)->isInstanceOf('\App\Libraries\AModel');
+        $this->object($entite)->isInstanceOf('\App\Libraries\AEntite');
     }
 
     /**
@@ -190,7 +190,7 @@ final class Repository extends \Atoum
         $entites = $repository->getList([]);
 
         $this->array($entites)->hasKey('Aladdin');
-        $this->object($entites['Aladdin'])->isInstanceOf('\App\Libraries\AModel');
+        $this->object($entites['Aladdin'])->isInstanceOf('\App\Libraries\AEntite');
     }
 
     /*************************************************
@@ -266,7 +266,7 @@ final class Repository extends \Atoum
 
         $entite = $repository->regenerateToken($this->entite);
 
-        $this->object($entite)->isInstanceOf(AModel::class);
+        $this->object($entite)->isInstanceOf(AEntite::class);
     }
 
     /*************************************************

--- a/Tests/Units/App/Components/Utilisateur/Repository.php
+++ b/Tests/Units/App/Components/Utilisateur/Repository.php
@@ -215,11 +215,11 @@ final class Repository extends \Atoum
     public function testUpdateDateLastAccess()
     {
         $repo = new _Repository($this->dao);
-        $this->model->getMockController()->getToken = 'Tartuffe';
+        $this->entite->getMockController()->getToken = 'Tartuffe';
 
-        $repo->updateDateLastAccess($this->model);
+        $repo->updateDateLastAccess($this->entite);
 
-        $this->mock($this->model)->call('updateDateLastAccess')->once();
+        $this->mock($this->entite)->call('updateDateLastAccess')->once();
         $this->mock($this->dao)->call('put')->once();
 
     }

--- a/Tests/Units/App/Libraries/AEntite.php
+++ b/Tests/Units/App/Libraries/AEntite.php
@@ -4,7 +4,7 @@ namespace Tests\Units\App\Libraries;
 use \App\Libraries\AEntite as _AEntite;
 
 /**
- * Classe commune de test sur les modèles
+ * Classe commune de test sur les entités
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
@@ -14,7 +14,7 @@ use \App\Libraries\AEntite as _AEntite;
 abstract class AEntite extends \Atoum
 {
     /**
-     * @var \App\Libraries\AEntite $entite Modèle en cours de test
+     * @var \App\Libraries\AEntite $entite Entité en cours de test
      */
     protected $entite;
 

--- a/Tests/Units/App/Libraries/AModel.php
+++ b/Tests/Units/App/Libraries/AModel.php
@@ -1,7 +1,7 @@
 <?php
 namespace Tests\Units\App\Libraries;
 
-use \App\Libraries\AModel as _AModel;
+use \App\Libraries\AEntite as _AEntite;
 
 /**
  * Classe commune de test sur les modèles
@@ -11,10 +11,10 @@ use \App\Libraries\AModel as _AModel;
  *
  * @since 0.1
  */
-abstract class AModel extends \Atoum
+abstract class AEntite extends \Atoum
 {
     /**
-     * @var \App\Libraries\AModel $entite Modèle en cours de test
+     * @var \App\Libraries\AEntite $entite Modèle en cours de test
      */
     protected $entite;
 
@@ -31,10 +31,10 @@ abstract class AModel extends \Atoum
     /**
      * Asserters commun sur la construction avec id
      *
-     * @param _AModel $entite
+     * @param _AEntite $entite
      * @param int $id Id de l'objet
      */
-    final protected function assertConstructWithId(_AModel $entite, $id)
+    final protected function assertConstructWithId(_AEntite $entite, $id)
     {
         $this->integer($entite->getId())->isIdenticalTo($id);
     }
@@ -47,7 +47,7 @@ abstract class AModel extends \Atoum
     /**
      * Asserteurs communs sur le reset
      */
-    final protected function assertReset(_AModel $entite)
+    final protected function assertReset(_AEntite $entite)
     {
         $entite->reset();
 

--- a/Tests/Units/App/Libraries/AModel.php
+++ b/Tests/Units/App/Libraries/AModel.php
@@ -14,9 +14,9 @@ use \App\Libraries\AModel as _AModel;
 abstract class AModel extends \Atoum
 {
     /**
-     * @var \App\Libraries\AModel $model Modèle en cours de test
+     * @var \App\Libraries\AModel $entite Modèle en cours de test
      */
-    protected $model;
+    protected $entite;
 
     /**
     * Teste la méthode __construct avec un Id (typiquement lors d'un get())
@@ -31,12 +31,12 @@ abstract class AModel extends \Atoum
     /**
      * Asserters commun sur la construction avec id
      *
-     * @param _AModel $model
+     * @param _AModel $entite
      * @param int $id Id de l'objet
      */
-    final protected function assertConstructWithId(_AModel $model, $id)
+    final protected function assertConstructWithId(_AModel $entite, $id)
     {
-        $this->integer($model->getId())->isIdenticalTo($id);
+        $this->integer($entite->getId())->isIdenticalTo($id);
     }
 
     /**
@@ -47,10 +47,10 @@ abstract class AModel extends \Atoum
     /**
      * Asserteurs communs sur le reset
      */
-    final protected function assertReset(_AModel $model)
+    final protected function assertReset(_AModel $entite)
     {
-        $model->reset();
+        $entite->reset();
 
-        $this->variable($model->getId())->isNull();
+        $this->variable($entite->getId())->isNull();
     }
 }

--- a/Tests/Units/Middlewares/Identification.php
+++ b/Tests/Units/Middlewares/Identification.php
@@ -37,7 +37,7 @@ final class Identification extends \Atoum
     public function testIsTokenOkOk()
     {
         $this->calling($this->repository)->find = function () {
-            return new \App\Components\Utilisateur\Model([]);
+            return new \App\Components\Utilisateur\Entite([]);
         };
         $auth = new _Identification($this->request, $this->repository);
 

--- a/decisions.md
+++ b/decisions.md
@@ -1,3 +1,9 @@
+## 2017-09-12
+
+* Je renomme les modèles du design MVC en *entités*. Dans un contexte métier, la couche métier ne se résume pas à une seule classe et je ne veux pas perdre le lecteur en créant la confusion dans sa tête si une classe porte ce nom.
+
+~ Prytoegrian
+
 
 ## 2016-10-29
 


### PR DESCRIPTION
Fix #6

Le design architectural MVC ne signifie pas qu'il y a 3 classes, il signifie qu'il y a trois couches de responsabilités (`3-tier architecture`). Pour éviter tout doute sur ce que doit être la couche `Model`, je renomme la classe entre un autre nom, tout aussi signifiant sur ce qu'elle fait mais en évitant l'écueil énoncé.

J'en profite, du coup, pour dire que la couche `Model` se compose actuellement de : 
* Repository, chef d'orchestre et point d'entrée métier,
* Entité, ou domain model, représentant d'une sphère d'influence métier, avec des règles métier appliquées à des données,
* DAO, interacteur avec le stockage.