### PR TITLE
Ajout du journal dans l'API

### DIFF
--- a/Journal/JournalController.php
+++ b/Journal/JournalController.php
@@ -15,6 +15,13 @@ use Psr\Http\Message\ResponseInterface as IResponse;
  */
 final class JournalController extends \LibertAPI\Tools\Libraries\AController
 {
+    /**
+     * {@inheritDoc}
+     */
+    protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    {
+    }
+
     /*************************************************
      * GET
      *************************************************/
@@ -31,28 +38,23 @@ final class JournalController extends \LibertAPI\Tools\Libraries\AController
      */
     public function get(IRequest $request, IResponse $response, array $arguments)
     {
+        unset($arguments);
         try {
             $resources = $this->repository->getList(
                 $request->getQueryParams()
             );
-            $entites = [];
-            foreach ($resources as $resource) {
-                $entites[] = $this->buildData($resource);
-            }
-            $code = 200;
-            $data = [
-                'code' => $code,
-                'status' => 'success',
-                'message' => '',
-                'data' => $entites,
-            ];
-
-            return $response->withJson($data, $code);
         } catch (\UnexpectedValueException $e) {
             return $this->getResponseNoContent($response);
         } catch (\Exception $e) {
             throw $e;
         }
+
+        $entites = [];
+        foreach ($resources as $resource) {
+            $entites[] = $this->buildData($resource);
+        }
+
+        return $this->getResponseSuccess($response, $entites, 200);
     }
 
     /**

--- a/Journal/JournalController.php
+++ b/Journal/JournalController.php
@@ -1,0 +1,78 @@
+<?php
+namespace LibertAPI\Journal;
+
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+
+/**
+ * Contrôleur de journal
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ * @see \LibertAPI\Tests\Units\Journal\JournalController
+ */
+final class JournalController extends \LibertAPI\Tools\Libraries\AController
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * Execute l'ordre HTTP GET
+     *
+     * @param IRequest $request Requête Http
+     * @param IResponse $response Réponse Http
+     * @param array $arguments Arguments de route
+     *
+     * @return IResponse
+     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
+     */
+    public function get(IRequest $request, IResponse $response, array $arguments)
+    {
+        try {
+            $resources = $this->repository->getList(
+                $request->getQueryParams()
+            );
+            $entites = [];
+            foreach ($resources as $resource) {
+                $entites[] = $this->buildData($resource);
+            }
+            $code = 200;
+            $data = [
+                'code' => $code,
+                'status' => 'success',
+                'message' => '',
+                'data' => $entites,
+            ];
+
+            return $response->withJson($data, $code);
+        } catch (\UnexpectedValueException $e) {
+            return $this->getResponseNoContent($response);
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * Construit le « data » du json
+     *
+     * @param JournalEntite $entite Journal
+     *
+     * @return array
+     */
+    private function buildData(JournalEntite $entite)
+    {
+        return [
+            'id' => $entite->getId(),
+            'numeroPeriode' => $entite->getNumeroPeriode(),
+            'utilisateurActeur' => $entite->getUtilisateurActeur(),
+            'utilisateurObjet' => $entite->getUtilisateurObjet(),
+            'etat' => $entite->getEtat(),
+            'commentaire' => $entite->getCommentaire(),
+            'date' => $entite->getDate(),
+        ];
+    }
+
+}

--- a/Journal/JournalDao.php
+++ b/Journal/JournalDao.php
@@ -1,0 +1,107 @@
+<?php
+namespace LibertAPI\Journal;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+class JournalDao extends \LibertAPI\Tools\Libraries\ADao
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function getById($id)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getList(array $parametres)
+    {
+        $this->queryBuilder->select('*');
+        $this->setWhere($parametres);
+        if (!empty($parametres['limit'])) {
+            $this->queryBuilder->setFirstResult(0);
+            $this->queryBuilder->setMaxResults((int) $parametres['limit']);
+        }
+        $res = $this->queryBuilder->execute();
+
+        return $res->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function post(array $data)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function put(array $data, $id)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function delete($id)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /**
+     * Définit les filtres à appliquer à la requête
+     *
+     * @param array $parametres
+     * @example [filter => [], lt => 23, limit => 4]
+     */
+    private function setWhere(array $parametres)
+    {
+        if (!empty($parametres['id'])) {
+            $this->queryBuilder->andWhere('log_id = :id');
+            $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
+        }
+        if (!empty($parametres['lt'])) {
+            $this->queryBuilder->andWhere('log_id < :lt');
+            $this->queryBuilder->setParameter(':lt', (int) $parametres['lt']);
+        }
+        if (!empty($parametres['gt'])) {
+            $this->queryBuilder->andWhere('log_id > :gt');
+            $this->queryBuilder->setParameter(':gt', (int) $parametres['gt']);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getTableName()
+    {
+        return 'conges_logs';
+    }
+}

--- a/Journal/JournalEntite.php
+++ b/Journal/JournalEntite.php
@@ -1,0 +1,70 @@
+<?php
+namespace LibertAPI\Journal;
+
+/**
+ * @inheritDoc
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ * @see \LibertAPI\Tests\Units\Journal\JournalEntite
+ */
+class JournalEntite extends \LibertAPI\Tools\Libraries\AEntite
+{
+    /**
+     * @return int
+     */
+    public function getNumeroPeriode()
+    {
+        return (int) $this->getFreshData('numeroPeriode');
+    }
+
+    /**
+     * @return string
+     */
+    public function getUtilisateurActeur()
+    {
+        return $this->getFreshData('utilisateurActeur');
+    }
+
+    /**
+     * @return string
+     */
+    public function getUtilisateurObjet()
+    {
+        return $this->getFreshData('utilisateurObjet');
+    }
+
+    /**
+     * @return string
+     */
+    public function getEtat()
+    {
+        return $this->getFreshData('etat');
+    }
+
+    /**
+     * @return string
+     */
+    public function getCommentaire()
+    {
+        return $this->getFreshData('commentaire');
+    }
+
+    /**
+     * @return string
+     */
+    public function getDate()
+    {
+        return $this->getFreshData('date');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function populate(array $data)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+}

--- a/Journal/JournalEntite.php
+++ b/Journal/JournalEntite.php
@@ -10,7 +10,7 @@ namespace LibertAPI\Journal;
  * @since 0.5
  * @see \LibertAPI\Tests\Units\Journal\JournalEntite
  */
-class JournalEntite extends \LibertAPI\Tools\Libraries\AEntite
+final class JournalEntite extends \LibertAPI\Tools\Libraries\AEntite
 {
     /**
      * @return int

--- a/Journal/JournalRepository.php
+++ b/Journal/JournalRepository.php
@@ -1,0 +1,140 @@
+<?php
+namespace LibertAPI\Journal;
+
+use LibertAPI\Tools\Libraries\AEntite;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ * @see \LibertAPI\Tests\Units\Journal\JournalRepository
+ */
+class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function getOne($id)
+    {
+        throw new \RuntimeException('Journal#' . $id . ' is not a callable resource');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getList(array $parametres)
+    {
+        /* TODO: retourner une collection pour avoir le total, hors limite forcée (utile pour la pagination) */
+        /*
+        several params :
+        offset (first, !isset => 0) / start-after ?
+        Limit (nb elements)
+        filter (dimensions forced)
+        */
+        $data = $this->dao->getList($this->getParamsConsumer2Dao($parametres));
+        if (empty($data)) {
+            throw new \UnexpectedValueException('No resource match with these parameters');
+        }
+
+        $entites = [];
+        foreach ($data as $value) {
+            $entite = new JournalEntite($this->getDataDao2Entite($value));
+            $entites[$entite->getId()] = $entite;
+        }
+
+        return $entites;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getDataDao2Entite(array $dataDao)
+    {
+        return [
+            'id' => $dataDao['log_id'],
+            'numeroPeriode' => $dataDao['log_p_num'],
+            'utilisateurActeur' => $dataDao['log_user_login_par'],
+            'utilisateurObjet' => $dataDao['log_user_login_pour'],
+            'etat' => $dataDao['log_etat'],
+            'commentaire' => $dataDao['log_comment'],
+            'date' => $dataDao['log_date'],
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getParamsConsumer2Dao(array $paramsConsumer)
+    {
+        $filterInt = function ($var) {
+            return filter_var(
+                $var,
+                FILTER_VALIDATE_INT,
+                ['options' => ['min_range' => 1]]
+            );
+        };
+        $results = [];
+        if (!empty($paramsConsumer['limit'])) {
+            $results['limit'] = $filterInt($paramsConsumer['limit']);
+        }
+        if (!empty($paramsConsumer['start-after'])) {
+            $results['lt'] = $filterInt($paramsConsumer['start-after']);
+
+        }
+        if (!empty($paramsConsumer['start-before'])) {
+            $results['gt'] = $filterInt($paramsConsumer['start-before']);
+        }
+        return $results;
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function postOne(array $data, AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getEntite2DataDao(AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function putOne(array $data, AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteOne(AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+}

--- a/Planning/Creneau/CreneauController.php
+++ b/Planning/Creneau/CreneauController.php
@@ -197,7 +197,7 @@ final class CreneauController extends \LibertAPI\Tools\Libraries\AController
         try {
             $creneau = $this->repository->getOne($id, $planningId);
         } catch (\DomainException $e) {
-            return $this->getResponseNotFound($response, 'Element « creneaux#' . $id . ' » is not a valid resource');
+            return $this->getResponseNotFound($response, 'Element « creneau#' . $id . ' » is not a valid resource');
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }

--- a/Planning/PlanningController.php
+++ b/Planning/PlanningController.php
@@ -68,7 +68,7 @@ final class PlanningController extends \LibertAPI\Tools\Libraries\AController
         try {
             $planning = $this->repository->getOne($id);
         } catch (\DomainException $e) {
-            return $this->getResponseNotFound($response, 'Element « plannings#' . $id . ' » is not a valid resource');
+            return $this->getResponseNotFound($response, 'Element « planning#' . $id . ' » is not a valid resource');
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
@@ -188,7 +188,7 @@ final class PlanningController extends \LibertAPI\Tools\Libraries\AController
         try {
             $planning = $this->repository->getOne($id);
         } catch (\DomainException $e) {
-            return $this->getResponseNotFound($response, 'Element « plannings#' . $id . ' » is not a valid resource');
+            return $this->getResponseNotFound($response, 'Element « planning#' . $id . ' » is not a valid resource');
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
@@ -226,7 +226,7 @@ final class PlanningController extends \LibertAPI\Tools\Libraries\AController
             $planning = $this->repository->getOne($id);
             $this->repository->deleteOne($planning);
         } catch (\DomainException $e) {
-            return $this->getResponseNotFound($response, 'Element « plannings#' . $id . ' » is not a valid resource');
+            return $this->getResponseNotFound($response, 'Element « planning#' . $id . ' » is not a valid resource');
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }

--- a/Public/index.php
+++ b/Public/index.php
@@ -23,9 +23,9 @@ $app->get('/hello_world', function(IRequest $request, IResponse $response) {
     return $response->withJson('Hi there !');
 });
 
-require_once ROUTE_PATH . 'Planning.php';
 require_once ROUTE_PATH . 'Authentification.php';
+require_once ROUTE_PATH . 'Journal.php';
+require_once ROUTE_PATH . 'Planning.php';
 require_once ROUTE_PATH . 'Utilisateurs.php';
-
 /* Jump in ! */
 $app->run();

--- a/Public/index.php
+++ b/Public/index.php
@@ -23,7 +23,7 @@ $app->get('/hello_world', function(IRequest $request, IResponse $response) {
     return $response->withJson('Hi there !');
 });
 
-require_once ROUTE_PATH . 'Plannings.php';
+require_once ROUTE_PATH . 'Planning.php';
 require_once ROUTE_PATH . 'Authentification.php';
 require_once ROUTE_PATH . 'Utilisateurs.php';
 

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ Les réponses de l'API se font sous la spécification jsend. Autrement dit :
 
 # Routes disponibles
 Suivant les règles de l'architecture REST, les routes disponibles à ce jour sont :
-* `GET /plannings`
-* `POST /plannings`
-* `GET /plannings/{id}`
-* `PUT /plannings/{id}`
-* `DELETE /plannings/{id}`
-* `GET /plannings/{id}/creneaux`
-* `POST /plannings/{id}/creneaux`
-* `GET /plannings/{id}/creneaux/{id}`
-* `DELETE /plannings/{id}/creneaux/{id}`
+* `GET /planning`
+* `POST /planning`
+* `GET /planning/{id}`
+* `PUT /planning/{id}`
+* `DELETE /planning/{id}`
+* `GET /planning/{id}/creneau`
+* `POST /planning/{id}/creneau`
+* `GET /planning/{id}/creneau/{id}`
+* `DELETE /planning/{id}/creneau/{id}`
 
 # Versions
 

--- a/Tests/Units/Journal/JournalController.php
+++ b/Tests/Units/Journal/JournalController.php
@@ -1,8 +1,6 @@
 <?php
 namespace LibertAPI\Tests\Units\Journal;
 
-use \LibertAPI\Planning\PlanningController as _Controller;
-
 /**
  * Classe de test du contrôleur de journal
  *
@@ -14,12 +12,12 @@ use \LibertAPI\Planning\PlanningController as _Controller;
 final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\AController
 {
     /**
-     * @var \LibertAPI\Planning\PlanningRepository Mock du repository associé
+     * @var \LibertAPI\Journal\JournalRepository Mock du repository associé
      */
     private $repository;
 
     /**
-     * @var \LibertAPI\Planning\PlanningEntite Mock de l'entité associée
+     * @var \LibertAPI\Journal\JournalEntite Entité associée
      */
     private $entite;
 
@@ -32,7 +30,6 @@ final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\ACo
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\LibertAPI\Journal\JournalRepository();
-        $this->mockGenerator->orphanize('__construct');
         $this->entite = new \LibertAPI\Journal\JournalEntite([
             'id' => 42,
             'numeroPeriode' => 88,

--- a/Tests/Units/Journal/JournalController.php
+++ b/Tests/Units/Journal/JournalController.php
@@ -1,0 +1,104 @@
+<?php
+namespace LibertAPI\Tests\Units\Journal;
+
+use \LibertAPI\Planning\PlanningController as _Controller;
+
+/**
+ * Classe de test du contrôleur de journal
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\AController
+{
+    /**
+     * @var \LibertAPI\Planning\PlanningRepository Mock du repository associé
+     */
+    private $repository;
+
+    /**
+     * @var \LibertAPI\Planning\PlanningEntite Mock de l'entité associée
+     */
+    private $entite;
+
+    /**
+     * Init des tests
+     */
+    public function beforeTestMethod($method)
+    {
+        parent::beforeTestMethod($method);
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $this->repository = new \mock\LibertAPI\Journal\JournalRepository();
+        $this->mockGenerator->orphanize('__construct');
+        $this->entite = new \LibertAPI\Journal\JournalEntite([
+            'id' => 42,
+            'numeroPeriode' => 88,
+            'utilisateurActeur' => '4',
+            'utilisateurObjet' => '8',
+            'etat' => 'cassé',
+            'commentaire' => 'c\'est cassé',
+            'date' => 'now',
+        ]);
+    }
+
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * Teste la méthode get d'une liste trouvée
+     */
+    public function testGetListFound()
+    {
+        $this->calling($this->request)->getQueryParams = [];
+        $this->calling($this->repository)->getList = [
+            42 => $this->entite,
+        ];
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->get($this->request, $this->response, []);
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(200);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(200)
+            ->string['status']->isIdenticalTo('success')
+            ->string['message']->isIdenticalTo('')
+            //->array['data']->hasSize(1) // TODO: l'asserter atoum en sucre syntaxique est buggé, faire un ticket
+        ;
+        $this->array($data['data'][0])->hasKey('id');
+    }
+
+    /**
+     * Teste la méthode get d'une liste non trouvée
+     */
+    public function testGetListNotFound()
+    {
+        $this->calling($this->request)->getQueryParams = [];
+        $this->calling($this->repository)->getList = function () {
+            throw new \UnexpectedValueException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->get($this->request, $this->response, []);
+
+        $this->assertSuccessEmpty($response);
+    }
+
+    /**
+     * Teste le fallback de la méthode get d'une liste
+     */
+    public function testGetListFallback()
+    {
+        $this->calling($this->request)->getQueryParams = [];
+        $this->calling($this->repository)->getList = function () {
+            throw new \Exception('');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+
+        $this->exception(function () {
+            $this->testedInstance->get($this->request, $this->response, []);
+        })->isInstanceOf('\Exception');
+    }
+}

--- a/Tests/Units/Journal/JournalDao.php
+++ b/Tests/Units/Journal/JournalDao.php
@@ -1,0 +1,103 @@
+<?php
+namespace LibertAPI\Tests\Units\Journal;
+
+/**
+ * Classe de test du DAO de planning
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * Teste la méthode getById
+     */
+    public function testGetById()
+    {
+        $this->newTestedInstance($this->connector);
+
+        $this->exception(function () {
+            $this->testedInstance->delete([]);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /**
+     * Teste la méthode getList avec des critères non pertinents
+     */
+    public function testGetListNotFound()
+    {
+        $this->calling($this->result)->fetchAll = [];
+        $dao = $this->newTestedInstance($this->connector);
+
+        $get = $dao->getList([]);
+
+        $this->array($get)->isEmpty();
+    }
+
+    /**
+     * Teste la méthode getList avec des critères pertinents
+     */
+    public function testGetListFound()
+    {
+        $this->calling($this->result)->fetchAll = [['a']];
+        $dao = $this->newTestedInstance($this->connector);
+
+        $get = $dao->getList([]);
+
+        $this->array($get[0])->isNotEmpty();
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * Teste la méthode post quand tout est ok
+     */
+    public function testPostOk()
+    {
+        $this->newTestedInstance($this->connector);
+
+        $this->exception(function () {
+            $this->testedInstance->delete([]);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * Teste la méthode put quand tout est ok
+     */
+    public function testPutOk()
+    {
+        $this->newTestedInstance($this->connector);
+
+        $this->exception(function () {
+            $this->testedInstance->delete([]);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * Teste la méthode delete
+     */
+    public function testDeleteOk()
+    {
+        $this->newTestedInstance($this->connector);
+
+        $this->exception(function () {
+            $this->testedInstance->delete([]);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+}

--- a/Tests/Units/Journal/JournalEntite.php
+++ b/Tests/Units/Journal/JournalEntite.php
@@ -1,0 +1,69 @@
+<?php
+namespace LibertAPI\Tests\Units\Journal;
+
+/**
+ * Classe de test de l'entité journal
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+final class JournalEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEntite
+{
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithId()
+    {
+        $id = 3;
+        $numero = 93;
+        $utilisateurActeur = 'tintin';
+
+        $entite = $this->newTestedInstance([
+            'id' => $id,
+            'numeroPeriode' => $numero,
+            'utilisateurActeur' => $utilisateurActeur,
+            'utilisateurObjet' => 'milou',
+            'etat' => 'haddock',
+            'commentaire' => 'moulinsart',
+            'date' => '43',
+        ]);
+
+        $this->assertConstructWithId($entite, $id);
+        $this->integer($entite->getNumeroPeriode())->isIdenticalTo($numero);
+        $this->string($entite->getUtilisateurActeur())->isIdenticalTo($utilisateurActeur);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithoutId()
+    {
+        $entite = $this->newTestedInstance(['']);
+
+        $this->variable($entite->getId())->isNull();
+    }
+
+    /**
+     * Teste la méthode populate
+     */
+    public function testPopulate()
+    {
+        $this->newTestedInstance([]);
+
+        $this->exception(function () {
+            $this->testedInstance->populate([]);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testReset()
+    {
+        $entite = $this->newTestedInstance(['id' => 3, 'name' => 'name', 'status' => 'status']);
+
+        $this->assertReset($entite);
+    }
+}

--- a/Tests/Units/Journal/JournalRepository.php
+++ b/Tests/Units/Journal/JournalRepository.php
@@ -1,0 +1,142 @@
+<?php
+namespace LibertAPI\Tests\Units\Journal;
+
+use \LibertAPI\Journal\JournalRepository as _Repository;
+
+/**
+ * Classe de test du repository de journal
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+final class JournalRepository extends \Atoum
+{
+    /**
+     * @var \LibertAPI\Journal\JournalDao Mock du DAO associé
+     */
+    private $dao;
+
+    /**
+     * @var \LibertAPI\Journal\JournalEntite Entité associée
+     */
+    private $entite;
+
+    public function beforeTestMethod($method)
+    {
+        parent::beforeTestMethod($method);
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $this->dao = new \mock\LibertAPI\Journal\JournalDao();
+        $this->entite = new \LibertAPI\Journal\JournalEntite([
+            'id' => 42,
+            'numeroPeriode' => 88,
+            'utilisateurActeur' => '4',
+            'utilisateurObjet' => '8',
+            'etat' => 'cassé',
+            'commentaire' => 'c\'est cassé',
+            'date' => 'now',
+        ]);
+    }
+
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * Teste la méthode getOne
+     */
+    public function testGetOne()
+    {
+        $this->calling($this->dao)->getById = [];
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->getOne(99);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /**
+     * Teste la méthode getList avec des critères non pertinents
+     */
+    public function testGetListNotFound()
+    {
+        $this->calling($this->dao)->getList = [];
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->getList([]);
+        })->isInstanceOf(\UnexpectedValueException::class);
+    }
+
+    /**
+     * Teste la méthode getList avec des critères pertinents
+     */
+    public function testGetListFound()
+    {
+        $this->calling($this->dao)->getList = [[
+            'log_id' => '42',
+            'log_p_num' => 73,
+            'log_user_login_par' => 'tintin',
+            'log_user_login_pour' => 'milou',
+            'log_etat' => 'haddock',
+            'log_comment' => 'moulinsart',
+            'log_date' => '43',
+        ]];
+        $this->newTestedInstance($this->dao);
+
+        $entites = $this->testedInstance->getList([]);
+
+        $this->array($entites)->hasKey(42);
+        $this->object($entites[42])->isInstanceOf(\LibertAPI\Tools\Libraries\AEntite::class);
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * Teste la méthode postOne
+     */
+    public function testPostOne()
+    {
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->postOne([], $this->entite);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * Teste la méthode putOne
+     */
+    public function testPutOne()
+    {
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->putOne([], $this->entite);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * Teste la méthode deleteOne
+     */
+    public function testDeleteOne()
+    {
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->deleteOne($this->entite);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+}

--- a/Tests/Units/Tools/Helpers/Formatter.php
+++ b/Tests/Units/Tools/Helpers/Formatter.php
@@ -33,18 +33,6 @@ final class Formatter extends \Atoum
     }
 
     /**
-     * Teste la mise en StudlyCaps d'un mot en snake_case
-     */
-    public function testGetStudlyCapFromSnakeSnake()
-    {
-        $mot = 'snake_case_long';
-
-        $studly = _Formatter::getStudlyCapsFromSnake($mot);
-
-        $this->string($studly)->isIdenticalTo('SnakeCaseLong');
-    }
-
-    /**
      * Teste la mise en StudlyCaps d'un seul mot
      */
     public function testGetStudlyCapFromSnakeOneWord()
@@ -54,42 +42,6 @@ final class Formatter extends \Atoum
         $studly = _Formatter::getStudlyCapsFromSnake($mot);
 
         $this->string($studly)->isIdenticalTo('Mot');
-    }
-
-    /**
-     * Teste la mise au singulier d'une phrase avec « s »  final
-     */
-    public function testGetSingularTermWithFinalS()
-    {
-        $term = 'Phrase avec s';
-
-        $singular = _Formatter::getSingularTerm($term);
-
-        $this->string($singular)->isIdenticalTo('Phrase avec ');
-    }
-
-    /**
-     * Teste la mise au singulier d'une phrase avec « x »  final
-     */
-    public function testGetSingularTermWithFinalX()
-    {
-        $term = 'Phrase avec x';
-
-        $singular = _Formatter::getSingularTerm($term);
-
-        $this->string($singular)->isIdenticalTo('Phrase avec ');
-    }
-
-    /**
-     * Teste la mise au singulier d'une phrase sans « s » final
-     */
-    public function testGetSingulaTermWithoutFinalS()
-    {
-        $term = 'Phrase sans esse';
-
-        $singular = _Formatter::getSingularTerm($term);
-
-        $this->string($singular)->isIdenticalTo($term);
     }
 
     /**

--- a/Tests/Units/Tools/Libraries/ARestController.php
+++ b/Tests/Units/Tools/Libraries/ARestController.php
@@ -31,8 +31,8 @@ abstract class ARestController extends AController
         parent::beforeTestMethod($method);
         $this->currentEmploye = new UtilisateurEntite(['id' => 'user', 'isResp' => false]);
         $this->currentResponsable = new UtilisateurEntite(['id' => 'resp', 'isResp' => true]);
-
     }
+
     /*************************************************
      * GET
      *************************************************/

--- a/Tools/Helpers/Formatter.php
+++ b/Tools/Helpers/Formatter.php
@@ -37,6 +37,8 @@ class Formatter
      */
     public static function timeToSQLDatetime($timestamp)
     {
-        return date('Y-m-d H:i', $timestamp);
+        $format = 'Y-m-d H:i';
+        $date = date($format, $timestamp);
+        return (new \DateTimeImmutable($date))->format($format);
     }
 }

--- a/Tools/Helpers/Formatter.php
+++ b/Tools/Helpers/Formatter.php
@@ -18,46 +18,13 @@ class Formatter
      */
     public static function getStudlyCapsFromSnake($terme)
     {
-        $longueurTerme = strlen($terme);
-        $studly = '';
-        $i = 0;
-        while ($i < $longueurTerme) {
-            if ('_' === $terme[$i]) {
-                if (($i + 1) < $longueurTerme) {
-                    $studly .= ucfirst($terme[$i + 1]);
-                }
-                if (($i + 2) < $longueurTerme) {
-                    $i = $i+2;
-                } else {
-                    ++$i;
-                }
-            } else {
-                $studly .= $terme[$i];
-                ++$i;
-            }
+        $studlyCapsed = '';
+        $termeSepare = explode('_', $terme);
+        foreach ($termeSepare as $mot) {
+            $studlyCapsed .= ucfirst($mot);
         }
 
-        return ucfirst($studly);
-    }
-
-    /**
-     * Met au singulier un terme
-     *
-     * Comme il n'y a aucun moyen rapide de distinguer un « s / x » final légitime
-     * d'un mot au pluriel, fait la brute épaisse
-     *
-     * @param string $terme
-     *
-     * @return string
-     */
-    public static function getSingularTerm($terme)
-    {
-        $len = strlen($terme);
-        if (in_array($terme[$len - 1], ['s', 'x'], true)) {
-            return substr($terme, 0, $len - 1);
-        }
-
-        return $terme;
+        return $studlyCapsed;
     }
 
     /**

--- a/Tools/Middlewares.php
+++ b/Tools/Middlewares.php
@@ -112,9 +112,7 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
     $ressources = [];
     foreach ($paths as $value) {
         if (!is_numeric($value)) {
-            $ressources[] = Formatter::getSingularTerm(
-                Formatter::getStudlyCapsFromSnake($value)
-            );
+            $ressources[] = Formatter::getStudlyCapsFromSnake($value);
         }
     }
     $request = $request->withAttribute('nomRessources', implode('|', $ressources));

--- a/Tools/Route/Journal.php
+++ b/Tools/Route/Journal.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * Doit être importé après la création de $app. Ne créé rien.
+ *
+ * La convention de nommage est de mettre les routes au singulier
+ *
+ * La particularité du journal est qu'il n'est qu'en lecture /destruction seule.
+ * C'est le rôle de l'API d'insérer les événements quand ils arrivent, idem pour la modification.
+ */
+
+/* Routes sur le journal */
+$app->group('/journal', function () {
+    $journalNS = '\LibertAPI\Journal\JournalController';
+    /* Collection */
+    $this->get('', $journalNS .  ':get')->setName('getJournalListe');
+});

--- a/Tools/Route/Planning.php
+++ b/Tools/Route/Planning.php
@@ -2,11 +2,11 @@
 /*
  * Doit être importé après la création de $app. Ne créé rien.
  *
- * La convention de nommage est de mettre les routes au pluriel
+ * La convention de nommage est de mettre les routes au singulier
  */
 
 /* Routes sur le planning et associés */
-$app->group('/plannings', function () {
+$app->group('/planning', function () {
     $this->group('/{planningId:[0-9]+}', function () {
         /* Detail */
         $this->get('', 'controller:get')->setName('getPlanningDetail');
@@ -14,7 +14,7 @@ $app->group('/plannings', function () {
         $this->delete('', 'controller:delete')->setName('deletePlanningDetail');
 
         /* Dependances de plannings */
-        $this->group('/creneaux', function () {
+        $this->group('/creneau', function () {
             /* Detail creneaux */
             $this->get('/{creneauId:[0-9]+}', 'controller:get')->setName('getPlanningCreneauDetail');
             $this->put('/{creneauId:[0-9]+}', 'controller:put')->setName('putPlanningCreneauDetail');

--- a/decisions.md
+++ b/decisions.md
@@ -1,3 +1,8 @@
+## 2017-11-04
+* À l'origine, j'avais mis les routes au pluriel car la sémantique était meilleure (avec `GET /plannings`, je veux la liste des plannings), mais l'idée atteint ses limites quand on se confronte à la langue (ex : journaux). Obliger à tenir une map serait inutilement lourd, aussi je vais au plus simple et je mets toutes les routes au singulier.
+
+~ Prytoegrian
+
 ## 2017-09-12
 
 * Je renomme les modèles du design MVC en *entités*. Dans un contexte métier, la couche métier ne se résume pas à une seule classe et je ne veux pas perdre le lecteur en créant la confusion dans sa tête si une classe porte ce nom.


### PR DESCRIPTION
J'ai ajouté le journal dans l'API, je suis parti du principe qu'il ne devait être qu'en lecture et destruction seules (vis à vis des routes), donc je pense qu'on ne fera pas les autres, ces derniers étant gérés automatiquement par l'API en interne.

À ce propos, je pense que nous gagnerions du temps à ne faire que l'ordre `GET` pour le moment, ça permettra à l'API d'être dispo plus tôt pour le client web, les autres ordres restant côté client. Au fur et à mesure, on transférera les responsabilités.

Sinon... je me suis retrouvé dans un embûche pour la pluralisation des routes ; avec `journaux`, ça me paraissait relou d'avoir une map des mots au singulier / pluriel juste pour suivre une convention. J'ai fait au plus simple, j'ai changé la convention et toutes les routes sont à présent au singulier.