### PR TITLE
Ajout de la route de type d'absences

### DIFF
--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -154,7 +154,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         } catch (\DomainException $e) {
             return $this->getResponseNotFound($response, 'Element « type#' . $id . ' » is not a valid resource');
         } catch (\Exception $e) {
-            throw $e;
+            return $this->getResponseError($response, $e);
         }
 
         try {

--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -1,0 +1,111 @@
+<?php
+namespace LibertAPI\Absence\Type;
+
+use LibertAPI\Tools\Interfaces;
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+
+/**
+ * Contrôleur de type d'absence
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ * @see \Tests\Units\Absence\Type\TypeController
+ */
+final class TypeController extends \LibertAPI\Tools\Libraries\AController
+implements Interfaces\IGetable
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function get(IRequest $request, IResponse $response, array $arguments)
+    {
+        if (!isset($arguments['planningId'])) {
+            return $this->getList($request, $response);
+        }
+
+        return $this->getOne($response, (int) $arguments['planningId']);
+    }
+
+    /**
+     * Retourne un élément unique
+     *
+     * @param IResponse $response Réponse Http
+     * @param int $id ID de l'élément
+     *
+     * @return IResponse, 404 si l'élément n'est pas trouvé, 200 sinon
+     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
+     */
+    private function getOne(IResponse $response, $id)
+    {
+        try {
+            $planning = $this->repository->getOne($id);
+            $code = 200;
+            $data = [
+                'code' => $code,
+                'status' => 'success',
+                'message' => '',
+                'data' => $this->buildData($planning),
+            ];
+
+            return $response->withJson($data, $code);
+        } catch (\DomainException $e) {
+            return $this->getResponseNotFound($response, 'Element « plannings#' . $id . ' » is not a valid resource');
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * Retourne un tableau de plannings
+     *
+     * @param IRequest $request Requête Http
+     * @param IResponse $response Réponse Http
+     *
+     * @return IResponse
+     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
+     */
+    private function getList(IRequest $request, IResponse $response)
+    {
+        try {
+            $plannings = $this->repository->getList(
+                $request->getQueryParams()
+            );
+            $entites = [];
+            foreach ($plannings as $planning) {
+                $entites[] = $this->buildData($planning);
+            }
+            $code = 200;
+            $data = [
+                'code' => $code,
+                'status' => 'success',
+                'message' => '',
+                'data' => $entites,
+            ];
+
+            return $response->withJson($data, $code);
+        } catch (\UnexpectedValueException $e) {
+            return $this->getResponseNoContent($response);
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * Construit le « data » du json
+     *
+     * @param PlanningEntite $entite Planning
+     *
+     * @return array
+     */
+    private function buildData(PlanningEntite $entite)
+    {
+        return [
+            'id' => $entite->getId(),
+            'name' => $entite->getName(),
+            'status' => $entite->getStatus(),
+        ];
+    }
+}

--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -22,11 +22,11 @@ implements Interfaces\IGetable
      */
     public function get(IRequest $request, IResponse $response, array $arguments)
     {
-        if (!isset($arguments['planningId'])) {
+        if (!isset($arguments['typeId'])) {
             return $this->getList($request, $response);
         }
 
-        return $this->getOne($response, (int) $arguments['planningId']);
+        return $this->getOne($response, (int) $arguments['typeId']);
     }
 
     /**

--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -159,22 +159,15 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
 
         try {
             $this->repository->putOne($body, $resource);
-            $code = 204;
-            $data = [
-                'code' => $code,
-                'status' => 'success',
-                'message' => '',
-                'data' => '',
-            ];
-
-            return $response->withJson($data, $code);
         } catch (MissingArgumentException $e) {
             return $this->getResponseMissingArgument($response);
         } catch (\DomainException $e) {
             return $this->getResponseBadDomainArgument($response, $e);
         } catch (\Exception $e) {
-            throw $e;
+            return $this->getResponseError($response, $e);
         }
+
+        return $this->getResponseSuccess($response, '', 204);
     }
 
     /**

--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -96,16 +96,17 @@ implements Interfaces\IGetable
     /**
      * Construit le « data » du json
      *
-     * @param PlanningEntite $entite Planning
+     * @param TypeEntite $entite Type
      *
      * @return array
      */
-    private function buildData(PlanningEntite $entite)
+    private function buildData(TypeEntite $entite)
     {
         return [
             'id' => $entite->getId(),
-            'name' => $entite->getName(),
-            'status' => $entite->getStatus(),
+            'type' => $entite->getType(),
+            'libelle' => $entite->getLibelle(),
+            'libelleCourt' => $entite->getLibelleCourt(),
         ];
     }
 }

--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -76,7 +76,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
             );
             $entites = [];
             foreach ($responseResources as $responseResource) {
-                $entites[] = $this->buildData($responseResources);
+                $entites[] = $this->buildData($responseResource);
             }
             $code = 200;
             $data = [

--- a/Absence/Type/TypeDao.php
+++ b/Absence/Type/TypeDao.php
@@ -119,9 +119,9 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     {
         $this->queryBuilder->delete($this->getTableName());
         $this->setWhere(['ta_id' => $id]);
-        $this->queryBuilder->execute();
+        $res = $this->queryBuilder->execute();
 
-        return $this->queryBuilder->rowCount();
+        return $res->rowCount();
     }
 
     /**

--- a/Absence/Type/TypeDao.php
+++ b/Absence/Type/TypeDao.php
@@ -1,0 +1,148 @@
+<?php
+namespace LibertAPI\Absence\Type;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+class TypeDao extends \LibertAPI\Tools\Libraries\ADao
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function getById($id)
+    {
+        $this->queryBuilder->select('*');
+        $this->setWhere(['id' => $id]);
+        $res = $this->queryBuilder->execute();
+
+        return $res->fetch(\PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getList(array $parametres)
+    {
+        $this->queryBuilder->select('*');
+        $this->setWhere($parametres);
+        if (!empty($parametres['limit'])) {
+            $this->queryBuilder->setFirstResult(0);
+            $this->queryBuilder->setMaxResults((int) $parametres['limit']);
+        }
+        $res = $this->queryBuilder->execute();
+
+        return $res->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function post(array $data)
+    {
+        $this->queryBuilder->insert($this->getTableName());
+        $this->setValues($data);
+        $this->queryBuilder->execute();
+
+        return $this->storageConnector->lastInsertId();
+    }
+
+    /**
+     * Définit les values à insérer
+     *
+     * @param array $values
+     */
+    private function setValues(array $values)
+    {
+        $this->queryBuilder->setValue('name', ':name');
+        $this->queryBuilder->setParameter(':name', $values['name']);
+        $this->queryBuilder->setValue('status', $values['status']);
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function put(array $data, $id)
+    {
+        $this->queryBuilder->update($this->getTableName());
+        $this->setSet($data);
+        $this->queryBuilder->where('planning_id = :id');
+        $this->queryBuilder->setParameter(':id', $id);
+
+        $this->queryBuilder->execute();
+    }
+
+    private function setSet(array $parametres)
+    {
+        if (!empty($parametres['name'])) {
+            $this->queryBuilder->set('name', ':name');
+            $this->queryBuilder->setParameter(':name', $parametres['name']);
+        }
+        if (!empty($parametres['status'])) {
+            $this->queryBuilder->set('status', ':status');
+            $this->queryBuilder->setParameter(':status', $parametres['status']);
+        }
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function delete($id)
+    {
+        $this->queryBuilder->delete();
+        $this->setWhere(['id' => $id]);
+        $res = $this->queryBuilder->execute();
+
+        return $res->rowCount();
+    }
+
+    /**
+     * Définit les filtres à appliquer à la requête
+     *
+     * @param array $parametres
+     * @example [filter => [], lt => 23, limit => 4]
+     */
+    private function setWhere(array $parametres)
+    {
+        if (!empty($parametres['id'])) {
+            $this->queryBuilder->andWhere('planning_id = :id');
+            $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
+        }
+        if (!empty($parametres['lt'])) {
+            $this->queryBuilder->andWhere('planning_id < :lt');
+            $this->queryBuilder->setParameter(':lt', (int) $parametres['lt']);
+        }
+        if (!empty($parametres['gt'])) {
+            $this->queryBuilder->andWhere('planning_id > :gt');
+            $this->queryBuilder->setParameter(':gt', (int) $parametres['gt']);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getTableName()
+    {
+        return 'conges_type_absence';
+    }
+}

--- a/Absence/Type/TypeDao.php
+++ b/Absence/Type/TypeDao.php
@@ -66,9 +66,12 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
      */
     private function setValues(array $values)
     {
-        $this->queryBuilder->setValue('name', ':name');
-        $this->queryBuilder->setParameter(':name', $values['name']);
-        $this->queryBuilder->setValue('status', $values['status']);
+        $this->queryBuilder->setValue('ta_type', ':type');
+        $this->queryBuilder->setParameter(':type', $values['type']);
+        $this->queryBuilder->setValue('ta_libelle', ':libelle');
+        $this->queryBuilder->setParameter(':libelle', $values['libelle']);
+        $this->queryBuilder->setValue('ta_short_libelle', ':libelleCourt');
+        $this->queryBuilder->setParameter(':libelleCourt', $values['libelleCourt']);
     }
 
     /*************************************************
@@ -82,7 +85,7 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     {
         $this->queryBuilder->update($this->getTableName());
         $this->setSet($data);
-        $this->queryBuilder->where('planning_id = :id');
+        $this->queryBuilder->where('ta_id = :id');
         $this->queryBuilder->setParameter(':id', $id);
 
         $this->queryBuilder->execute();
@@ -90,13 +93,18 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
 
     private function setSet(array $parametres)
     {
-        if (!empty($parametres['name'])) {
-            $this->queryBuilder->set('name', ':name');
-            $this->queryBuilder->setParameter(':name', $parametres['name']);
+        if (!empty($parametres['type'])) {
+            $this->queryBuilder->set('ta_type', ':type');
+            $this->queryBuilder->setParameter(':type', $parametres['type']);
         }
-        if (!empty($parametres['status'])) {
-            $this->queryBuilder->set('status', ':status');
-            $this->queryBuilder->setParameter(':status', $parametres['status']);
+        if (!empty($parametres['libelle'])) {
+            $this->queryBuilder->set('ta_libelle', ':libelle');
+            // @TODO : changer le schema
+            $this->queryBuilder->setParameter(':libelle', $parametres['libelle']);
+        }
+        if (!empty($parametres['libelleCourt'])) {
+            $this->queryBuilder->set('ta_short_libelle', ':libelleCourt');
+            $this->queryBuilder->setParameter(':libelleCourt', $parametres['libelleCourt']);
         }
     }
 
@@ -109,11 +117,11 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
      */
     public function delete($id)
     {
-        $this->queryBuilder->delete();
-        $this->setWhere(['id' => $id]);
-        $res = $this->queryBuilder->execute();
+        $this->queryBuilder->delete($this->getTableName());
+        $this->setWhere(['ta_id' => $id]);
+        $this->queryBuilder->execute();
 
-        return $res->rowCount();
+        return $this->queryBuilder->rowCount();
     }
 
     /**

--- a/Absence/Type/TypeDao.php
+++ b/Absence/Type/TypeDao.php
@@ -125,7 +125,7 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     private function setWhere(array $parametres)
     {
         if (!empty($parametres['id'])) {
-            $this->queryBuilder->andWhere('planning_id = :id');
+            $this->queryBuilder->andWhere('ta_id = :id');
             $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
         }
         if (!empty($parametres['lt'])) {

--- a/Absence/Type/TypeEntite.php
+++ b/Absence/Type/TypeEntite.php
@@ -26,7 +26,7 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
      * Retourne la donnée la plus à jour du champ libelle
      *
      * @return string
-     * @TODO : changer le schema bd, le transtypage ne devrait pas être nécessaire
+     * @TODO : changer le schema bd, le transcodage ne devrait pas être nécessaire
      */
     public function getLibelle()
     {
@@ -75,7 +75,6 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
 
         $this->dataUpdated['name'] = $name;
     }
-
 
     /**
      * Tente l'insertion d'une donnée en tant que champ « status »

--- a/Absence/Type/TypeEntite.php
+++ b/Absence/Type/TypeEntite.php
@@ -1,0 +1,98 @@
+<?php
+namespace LibertAPI\Absence\Type;
+
+/**
+ * @inheritDoc
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ * @see \LibertAPI\Tests\Units\Absence\Type\TypeEntite
+ */
+class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
+{
+    /**
+     * Retourne la donnée la plus à jour du champ type
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->getFreshData('type');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ libelle
+     *
+     * @return string
+     * @TODO : changer le schema bd, le transtypage ne devrait pas être nécessaire
+     */
+    public function getLibelle()
+    {
+        return utf8_encode($this->getFreshData('libelle'));
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ libelle court
+     *
+     * @return string
+     */
+    public function getLibelleCourt()
+    {
+        return $this->getFreshData('libelleCourt');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function populate(array $data)
+    {
+        $this->setName($data['name']);
+        $this->setStatus($data['status']);
+
+        $erreurs = $this->getErreurs();
+        if (!empty($erreurs)) {
+            throw new \DomainException(json_encode($erreurs));
+        }
+    }
+
+    /**
+     * Tente l'insertion d'une donnée en tant que champ « name »
+     *
+     * Stocke une erreur si la donnée ne colle pas au domaine
+     *
+     * @param string $name
+     * @todo
+     */
+    private function setName($name)
+    {
+        // domaine de name ?
+        if (empty($name)) {
+            $this->setErreur('name', 'Le champ est vide');
+            return;
+        }
+
+        $this->dataUpdated['name'] = $name;
+    }
+
+
+    /**
+     * Tente l'insertion d'une donnée en tant que champ « status »
+     *
+     * Stocke une erreur si la donnée ne colle pas au domaine
+     *
+     * @param string $status
+     * @todo
+     */
+    private function setStatus($status)
+    {
+        // domaine de status ?
+        if (empty($status)) {
+            $this->setErreur('status', 'Le champ est vide');
+            return;
+        }
+
+        $this->dataUpdated['status'] = $status;
+    }
+}

--- a/Absence/Type/TypeEntite.php
+++ b/Absence/Type/TypeEntite.php
@@ -30,7 +30,12 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
      */
     public function getLibelle()
     {
-        return utf8_encode($this->getFreshData('libelle'));
+        if ('utf-8' !== strtolower(mb_detect_encoding($this->getFreshData('libelle')))) {
+            return utf8_encode($this->getFreshData('libelle'));
+        }
+
+        return $this->getFreshData('libelle');
+
     }
 
     /**
@@ -48,8 +53,9 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
      */
     public function populate(array $data)
     {
-        $this->setName($data['name']);
-        $this->setStatus($data['status']);
+        $this->setType($data['type']);
+        $this->setLibelle($data['libelle']);
+        $this->setLibelleCourt($data['libelleCourt']);
 
         $erreurs = $this->getErreurs();
         if (!empty($erreurs)) {
@@ -58,40 +64,60 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
     }
 
     /**
-     * Tente l'insertion d'une donnée en tant que champ « name »
+     * Tente l'insertion d'une donnée en tant que champ « type »
      *
      * Stocke une erreur si la donnée ne colle pas au domaine
      *
-     * @param string $name
+     * @param string $type
      * @todo
      */
-    private function setName($name)
+    private function setType($type)
     {
-        // domaine de name ?
-        if (empty($name)) {
-            $this->setErreur('name', 'Le champ est vide');
+        // domaine ?
+        if (empty($type)) {
+            $this->setErreur('type', 'Le champ est vide');
             return;
         }
 
-        $this->dataUpdated['name'] = $name;
+        $this->dataUpdated['type'] = $type;
     }
 
     /**
-     * Tente l'insertion d'une donnée en tant que champ « status »
+     * Tente l'insertion d'une donnée en tant que champ « libelle »
      *
      * Stocke une erreur si la donnée ne colle pas au domaine
      *
-     * @param string $status
+     * @param string $var
      * @todo
      */
-    private function setStatus($status)
+    private function setLibelle($var)
     {
-        // domaine de status ?
-        if (empty($status)) {
-            $this->setErreur('status', 'Le champ est vide');
+        // domaine ?
+        if (empty($var)) {
+            $this->setErreur('libelle', 'Le champ est vide');
             return;
         }
 
-        $this->dataUpdated['status'] = $status;
+        $this->dataUpdated['libelle'] = $var;
     }
+
+    /**
+     * Tente l'insertion d'une donnée en tant que champ « libelleCourt »
+     *
+     * Stocke une erreur si la donnée ne colle pas au domaine
+     *
+     * @param string $var
+     * @todo
+     */
+    private function setLibelleCourt($var)
+    {
+        // domaine ?
+        if (empty($var)) {
+            $this->setErreur('libelleCourt', 'Le champ est vide');
+            return;
+        }
+
+        $this->dataUpdated['libelleCourt'] = $var;
+    }
+
 }

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -1,7 +1,6 @@
 <?php
 namespace LibertAPI\Absence\Type;
 
-use LibertAPI\Tools\Exceptions\MissingArgumentException;
 use LibertAPI\Tools\Libraries\AEntite;
 
 /**
@@ -94,25 +93,6 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AEntite $entite)
-    {
-        if (!$this->hasAllRequired($data)) {
-            throw new MissingArgumentException('');
-        }
-
-        try {
-            $entite->populate($data);
-            $dataDao = $this->getEntite2DataDao($entite);
-
-            return $this->dao->post($dataDao);
-        } catch (\Exception $e) {
-            throw $e;
-        }
-    }
-
-    /**
-     * @inheritDoc
-     */
     final protected function getEntite2DataDao(AEntite $entite)
     {
         return [
@@ -123,50 +103,11 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
     }
 
     /**
-     * Vérifie que les données passées possèdent bien tous les champs requis
-     *
-     * @param array $data
-     *
-     * @return bool
+     * {@inheritDoc}
      */
-    private function hasAllRequired(array $data)
-    {
-        foreach ($this->getListRequired() as $value) {
-            if (!isset($data[$value])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Retourne la liste des champs requis
-     *
-     * @return array
-     */
-    private function getListRequired()
+    protected function getListRequired()
     {
         return ['type', 'libelle', 'libelleCourt'];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function putOne(array $data, AEntite $entite)
-    {
-        if (!$this->hasAllRequired($data)) {
-            throw new MissingArgumentException('');
-        }
-
-        try {
-            $entite->populate($data);
-            $dataDao = $this->getEntite2DataDao($entite);
-
-            return $this->dao->put($dataDao, $entite->getId());
-        } catch (\Exception $e) {
-            throw $e;
-        }
     }
 
     /**

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -1,0 +1,118 @@
+<?php
+namespace LibertAPI\Absence\Type;
+
+use LibertAPI\Tools\Libraries\AEntite;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ * @see \Tests\Units\Absence\Type\TypeRepository
+ */
+class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function getOne($id)
+    {
+        $id = (int) $id;
+        $data = $this->dao->getById($id);
+        if (empty($data)) {
+            throw new \DomainException('Type#' . $id . ' is not a valid resource');
+        }
+
+        return new TypeEntite($this->getDataDao2Entite($data));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getList(array $parametres)
+    {
+        $data = $this->dao->getList($this->getParamsConsumer2Dao($parametres));
+        if (empty($data)) {
+            throw new \UnexpectedValueException('No resource match with these parameters');
+        }
+
+        $entites = [];
+        foreach ($data as $value) {
+            $entite = new TypeEntite($this->getDataDao2Entite($value));
+            $entites[$entite->getId()] = $entite;
+        }
+
+        return $entites;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getDataDao2Entite(array $dataDao)
+    {
+        return [
+            'id' => $dataDao['planning_id'],
+            'name' => $dataDao['name'],
+            'status' => $dataDao['status'],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    final protected function getParamsConsumer2Dao(array $paramsConsumer)
+    {
+        $filterInt = function ($var) {
+            return filter_var(
+                $var,
+                FILTER_VALIDATE_INT,
+                ['options' => ['min_range' => 1]]
+            );
+        };
+        $results = [];
+        if (!empty($paramsConsumer['limit'])) {
+            $results['limit'] = $filterInt($paramsConsumer['limit']);
+        }
+        if (!empty($paramsConsumer['start-after'])) {
+            $results['lt'] = $filterInt($paramsConsumer['start-after']);
+
+        }
+        if (!empty($paramsConsumer['start-before'])) {
+            $results['gt'] = $filterInt($paramsConsumer['start-before']);
+        }
+        return $results;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function postOne(array $data, AEntite $entite)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getEntite2DataDao(AEntite $entite)
+    {}
+
+    /**
+     * @inheritDoc
+     */
+    public function putOne(array $data, AEntite $entite)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteOne(AEntite $entite)
+    {
+    }
+}

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -1,6 +1,7 @@
 <?php
 namespace LibertAPI\Absence\Type;
 
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
 use LibertAPI\Tools\Libraries\AEntite;
 
 /**
@@ -95,19 +96,77 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     public function postOne(array $data, AEntite $entite)
     {
+        if (!$this->hasAllRequired($data)) {
+            throw new MissingArgumentException('');
+        }
+
+        try {
+            $entite->populate($data);
+            $dataDao = $this->getEntite2DataDao($entite);
+
+            return $this->dao->post($dataDao);
+        } catch (\Exception $e) {
+            throw $e;
+        }
     }
 
     /**
      * @inheritDoc
      */
     final protected function getEntite2DataDao(AEntite $entite)
-    {}
+    {
+        return [
+            'type' => $entite->getType(),
+            'libelle' => $entite->getLibelle(),
+            'libelleCourt' => $entite->getLibelleCourt(),
+        ];
+    }
+
+    /**
+     * Vérifie que les données passées possèdent bien tous les champs requis
+     *
+     * @param array $data
+     *
+     * @return bool
+     */
+    private function hasAllRequired(array $data)
+    {
+        foreach ($this->getListRequired() as $value) {
+            if (!isset($data[$value])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Retourne la liste des champs requis
+     *
+     * @return array
+     */
+    private function getListRequired()
+    {
+        return ['type', 'libelle', 'libelleCourt'];
+    }
 
     /**
      * @inheritDoc
      */
     public function putOne(array $data, AEntite $entite)
     {
+        if (!$this->hasAllRequired($data)) {
+            throw new MissingArgumentException('');
+        }
+
+        try {
+            $entite->populate($data);
+            $dataDao = $this->getEntite2DataDao($entite);
+
+            return $this->dao->put($dataDao, $entite->getId());
+        } catch (\Exception $e) {
+            throw $e;
+        }
     }
 
     /**
@@ -115,5 +174,11 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     public function deleteOne(AEntite $entite)
     {
+        try {
+            $entite->reset();
+            $this->dao->delete($entite->getId());
+        } catch (\Exception $e) {
+            throw $e;
+        }
     }
 }

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -57,9 +57,10 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
     final protected function getDataDao2Entite(array $dataDao)
     {
         return [
-            'id' => $dataDao['planning_id'],
-            'name' => $dataDao['name'],
-            'status' => $dataDao['status'],
+            'id' => $dataDao['ta_id'],
+            'type' => $dataDao['ta_type'],
+            'libelle' => $dataDao['ta_libelle'],
+            'libelleCourt' => $dataDao['ta_short_libelle'],
         ];
     }
 

--- a/Authentification/AuthentificationController.php
+++ b/Authentification/AuthentificationController.php
@@ -3,6 +3,7 @@ namespace LibertAPI\Authentification;
 
 use LibertAPI\Tools\Libraries\ARepository;
 use \Slim\Interfaces\RouterInterface as IRouter;
+use LibertAPI\Tools\Interfaces;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use Psr\Http\Message\ResponseInterface as IResponse;
 
@@ -16,6 +17,7 @@ use Psr\Http\Message\ResponseInterface as IResponse;
  * @see \Tests\Units\Authentification\AuthentificationController
  */
 final class AuthentificationController extends \LibertAPI\Tools\Libraries\AController
+implements Interfaces\IGetable
 {
     public function __construct(ARepository $repository, IRouter $router)
     {
@@ -30,19 +32,10 @@ final class AuthentificationController extends \LibertAPI\Tools\Libraries\AContr
     {
     }
 
-    /*************************************************
-     * GET
-     *************************************************/
-
     /**
-     * Execute l'ordre HTTP GET pour la récupération du token
-     *
-     * @param IRequest $request Requête Http
-     * @param IResponse $response Réponse Http
-     *
-     * @return IResponse
+     * {@inheritDoc}
      */
-    public function get(IRequest $request, IResponse $response)
+    public function get(IRequest $request, IResponse $response, array $arguments)
     {
         $authentificationType = 'Basic';
         $authentification = $request->getHeaderLine('Authorization');

--- a/Journal/JournalRepository.php
+++ b/Journal/JournalRepository.php
@@ -106,6 +106,11 @@ class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
         throw new \RuntimeException('Action is forbidden');
     }
 
+    protected function getListRequired()
+    {
+        return [];
+    }
+
     /**
      * @inheritDoc
      */

--- a/Planning/Creneau/CreneauController.php
+++ b/Planning/Creneau/CreneauController.php
@@ -2,6 +2,8 @@
 namespace LibertAPI\Planning\Creneau;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
+use LibertAPI\Tools\Interfaces;
+
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use Psr\Http\Message\ResponseInterface as IResponse;
 
@@ -18,6 +20,7 @@ use Psr\Http\Message\ResponseInterface as IResponse;
  * Ne devrait contacter que le Planning\Repository
  */
 final class CreneauController extends \LibertAPI\Tools\Libraries\AController
+implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable
 {
     /**
      * {@inheritDoc}
@@ -26,19 +29,8 @@ final class CreneauController extends \LibertAPI\Tools\Libraries\AController
     {
     }
 
-    /*************************************************
-     * GET
-     *************************************************/
-
     /**
-     * Execute l'ordre HTTP GET
-     *
-     * @param IRequest $request Requête Http
-     * @param IResponse $response Réponse Http
-     * @param array $arguments Arguments de route
-     *
-     * @return IResponse
-     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
+     * {@inheritDoc}
      */
     public function get(IRequest $request, IResponse $response, array $arguments)
     {
@@ -122,20 +114,9 @@ final class CreneauController extends \LibertAPI\Tools\Libraries\AController
         ];
     }
 
-    /*************************************************
-     * POST
-     *************************************************/
-
-     /**
-      * Execute l'ordre HTTP POST
-      *
-      * @param IRequest $request Requête Http
-      * @param IResponse $response Réponse Http
-      * @param array $arguments Arguments de route
-      *
-      * @return IResponse
-      * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
-      */
+    /**
+     * {@inheritDoc}
+     */
     public function post(IRequest $request, IResponse $response, array $arguments)
     {
         $body = $request->getParsedBody();
@@ -171,19 +152,8 @@ final class CreneauController extends \LibertAPI\Tools\Libraries\AController
         );
     }
 
-    /*************************************************
-     * PUT
-     *************************************************/
-
     /**
-     * Execute l'ordre HTTP PUT
-     *
-     * @param IRequest $request Requête Http
-     * @param IResponse $response Réponse Http
-     * @param array $arguments Arguments de route
-     *
-     * @return IResponse
-     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
+     * {@inheritDoc}
      */
     public function put(IRequest $request, IResponse $response, array $arguments)
     {

--- a/Planning/Creneau/CreneauRepository.php
+++ b/Planning/Creneau/CreneauRepository.php
@@ -130,25 +130,6 @@ class CreneauRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AEntite $entite)
-    {
-        if (!$this->hasAllRequired($data)) {
-            throw new MissingArgumentException('');
-        }
-
-        try {
-            $entite->populate($data);
-            $dataDao = $this->getEntite2DataDao($entite);
-
-            return $this->dao->post($dataDao);
-        } catch (\Exception $e) {
-            throw $e;
-        }
-    }
-
-    /**
-     * @inheritDoc
-     */
     final protected function getEntite2DataDao(AEntite $entite)
     {
         return [
@@ -162,54 +143,11 @@ class CreneauRepository extends \LibertAPI\Tools\Libraries\ARepository
     }
 
     /**
-     * Vérifie que les données passées possèdent bien tous les champs requis
-     *
-     * @param array $data
-     *
-     * @return bool
+     * {@inheritDoc}
      */
-    private function hasAllRequired(array $data)
-    {
-        foreach ($this->getListRequired() as $value) {
-            if (!isset($data[$value])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Retourne la liste des champs requis
-     *
-     * @return array
-     */
-    private function getListRequired()
+    protected function getListRequired()
     {
         return ['planningId', 'jourId', 'typeSemaine', 'typePeriode', 'debut', 'fin'];
-    }
-
-    /*************************************************
-     * PUT
-     *************************************************/
-
-    /**
-     * @inheritDoc
-     */
-    public function putOne(array $data, AEntite $entite)
-    {
-        if (!$this->hasAllRequired($data)) {
-            throw new MissingArgumentException('');
-        }
-
-        try {
-            $entite->populate($data);
-            $dataDao = $this->getEntite2DataDao($entite);
-
-            return $this->dao->put($dataDao, $entite->getId());
-        } catch (\Exception $e) {
-            throw $e;
-        }
     }
 
     /*************************************************

--- a/Planning/PlanningController.php
+++ b/Planning/PlanningController.php
@@ -2,6 +2,7 @@
 namespace LibertAPI\Planning;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
+use LibertAPI\Tools\Interfaces;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use Psr\Http\Message\ResponseInterface as IResponse;
 
@@ -18,6 +19,7 @@ use Psr\Http\Message\ResponseInterface as IResponse;
  * Ne devrait contacter que le Planning\Repository
  */
 final class PlanningController extends \LibertAPI\Tools\Libraries\AController
+implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Interfaces\IDeletable
 {
     /**
      * {@inheritDoc}
@@ -33,18 +35,8 @@ final class PlanningController extends \LibertAPI\Tools\Libraries\AController
         }
     }
 
-    /*************************************************
-     * GET
-     *************************************************/
-
     /**
-     * Execute l'ordre HTTP GET
-     *
-     * @param IRequest $request Requête Http
-     * @param IResponse $response Réponse Http
-     * @param array $arguments Arguments de route
-     *
-     * @return IResponse
+     * {@inheritDoc}
      */
     public function get(IRequest $request, IResponse $response, array $arguments)
     {
@@ -126,19 +118,10 @@ final class PlanningController extends \LibertAPI\Tools\Libraries\AController
         ];
     }
 
-    /*************************************************
-     * POST
-     *************************************************/
-
-     /**
-      * Execute l'ordre HTTP POST
-      *
-      * @param IRequest $request Requête Http
-      * @param IResponse $response Réponse Http
-      *
-      * @return IResponse
-      */
-    public function post(IRequest $request, IResponse $response)
+    /**
+     * {@inheritDoc}
+     */
+    public function post(IRequest $request, IResponse $response, array $routeArguments)
     {
         $body = $request->getParsedBody();
         if (null === $body) {
@@ -164,18 +147,8 @@ final class PlanningController extends \LibertAPI\Tools\Libraries\AController
         );
     }
 
-    /*************************************************
-     * PUT
-     *************************************************/
-
     /**
-     * Execute l'ordre HTTP PUT
-     *
-     * @param IRequest $request Requête Http
-     * @param IResponse $response Réponse Http
-     * @param array $arguments Arguments de route
-     *
-     * @return IResponse
+     * {@inheritDoc}
      */
     public function put(IRequest $request, IResponse $response, array $arguments)
     {
@@ -206,19 +179,9 @@ final class PlanningController extends \LibertAPI\Tools\Libraries\AController
         return $this->getResponseSuccess($response, '', 204);
     }
 
-    /*************************************************
-     * DELETE
-     *************************************************/
-
-     /**
-      * Execute l'ordre HTTP DELETE
-      *
-      * @param IRequest $request Requête Http
-      * @param IResponse $response Réponse Http
-      * @param array $arguments Arguments de route
-      *
-      * @return IResponse
-      */
+    /**
+     * {@inheritDoc}
+     */
     public function delete(IRequest $request, IResponse $response, array $arguments)
     {
         $id = (int) $arguments['planningId'];

--- a/Planning/PlanningDao.php
+++ b/Planning/PlanningDao.php
@@ -112,11 +112,11 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
      */
     public function delete($id)
     {
-        $this->queryBuilder->delete();
+        $this->queryBuilder->delete($this->getTableName());
         $this->setWhere(['id' => $id]);
-        $res = $this->queryBuilder->execute();
+        $this->queryBuilder->execute();
 
-        return $res->rowCount();
+        return $this->queryBuilder->rowCount();
     }
 
     /**

--- a/Planning/PlanningDao.php
+++ b/Planning/PlanningDao.php
@@ -84,9 +84,9 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     public function put(array $data, $id)
     {
         $this->queryBuilder->update($this->getTableName());
-        $this->setSet($data);
         $this->queryBuilder->where('planning_id = :id');
         $this->queryBuilder->setParameter(':id', $id);
+        $this->setSet($data);
 
         $this->queryBuilder->execute();
     }
@@ -114,9 +114,9 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     {
         $this->queryBuilder->delete($this->getTableName());
         $this->setWhere(['id' => $id]);
-        $this->queryBuilder->execute();
+        $res = $this->queryBuilder->execute();
 
-        return $this->queryBuilder->rowCount();
+        return $res->rowCount();
     }
 
     /**

--- a/Planning/PlanningRepository.php
+++ b/Planning/PlanningRepository.php
@@ -107,25 +107,6 @@ class PlanningRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AEntite $entite)
-    {
-        if (!$this->hasAllRequired($data)) {
-            throw new MissingArgumentException('');
-        }
-
-        try {
-            $entite->populate($data);
-            $dataDao = $this->getEntite2DataDao($entite);
-
-            return $this->dao->post($dataDao);
-        } catch (\Exception $e) {
-            throw $e;
-        }
-    }
-
-    /**
-     * @inheritDoc
-     */
     final protected function getEntite2DataDao(AEntite $entite)
     {
         return [
@@ -135,54 +116,11 @@ class PlanningRepository extends \LibertAPI\Tools\Libraries\ARepository
     }
 
     /**
-     * Vérifie que les données passées possèdent bien tous les champs requis
-     *
-     * @param array $data
-     *
-     * @return bool
+     * {@inheritDoc}
      */
-    private function hasAllRequired(array $data)
-    {
-        foreach ($this->getListRequired() as $value) {
-            if (!isset($data[$value])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Retourne la liste des champs requis
-     *
-     * @return array
-     */
-    private function getListRequired()
+    protected function getListRequired()
     {
         return ['name', 'status'];
-    }
-
-    /*************************************************
-     * PUT
-     *************************************************/
-
-    /**
-     * @inheritDoc
-     */
-    public function putOne(array $data, AEntite $entite)
-    {
-        if (!$this->hasAllRequired($data)) {
-            throw new MissingArgumentException('');
-        }
-
-        try {
-            $entite->populate($data);
-            $dataDao = $this->getEntite2DataDao($entite);
-
-            return $this->dao->put($dataDao, $entite->getId());
-        } catch (\Exception $e) {
-            throw $e;
-        }
     }
 
     /*************************************************

--- a/Public/index.php
+++ b/Public/index.php
@@ -23,6 +23,7 @@ $app->get('/hello_world', function(IRequest $request, IResponse $response) {
     return $response->withJson('Hi there !');
 });
 
+require_once ROUTE_PATH . 'Absence.php';
 require_once ROUTE_PATH . 'Authentification.php';
 require_once ROUTE_PATH . 'Journal.php';
 require_once ROUTE_PATH . 'Planning.php';

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Les réponses de l'API se font sous la spécification jsend. Autrement dit :
 
 # Routes disponibles
 Suivant les règles de l'architecture REST, les routes disponibles à ce jour sont :
+* `GET /absences/types/{id}`
 * `GET /planning`
 * `POST /planning`
 * `GET /planning/{id}`

--- a/Tests/Units/Absence/Type/TypeController.php
+++ b/Tests/Units/Absence/Type/TypeController.php
@@ -1,0 +1,403 @@
+<?php
+namespace LibertAPI\Tests\Units\Absence\Type;
+
+/**
+ * Classe de test du contrôleur des type d'absence
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AController
+{
+    /**
+     * @var \LibertAPI\Tools\Libraries\ARepository Mock du repository associé
+     */
+    private $repository;
+
+    /**
+     * @var \LibertAPI\Tools\Libraries\AEntite Mock de l'entité associée
+     */
+    private $entite;
+
+    /**
+     * Init des tests
+     */
+    public function beforeTestMethod($method)
+    {
+        parent::beforeTestMethod($method);
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $this->repository = new \mock\LibertAPI\Absence\Type\TypeRepository();
+        $this->mockGenerator->orphanize('__construct');
+        $this->entite = new \LibertAPI\Absence\Type\TypeEntite([
+            'id' => 42,
+            'type' => 'thieft',
+            'libelle' => 'GTA',
+            'libelleCourt' => 'vice'
+        ]);
+    }
+
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * Teste la méthode get d'un détail trouvé
+     */
+    public function testGetOneFound()
+    {
+        $this->repository->getMockController()->getOne = $this->entite;
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->get($this->request, $this->response, ['typeId' => 99]);
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(200);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(200)
+            ->string['status']->isIdenticalTo('success')
+            ->string['message']->isIdenticalTo('')
+            ->array['data']->isNotEmpty()
+        ;
+    }
+
+    /**
+     * Teste la méthode get d'un détail non trouvé
+     */
+    public function testGetOneNotFound()
+    {
+        $this->repository->getMockController()->getOne = function () {
+            throw new \DomainException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->get($this->request, $this->response, ['typeId' => 99]);
+
+        $this->assertError($response, 404);
+    }
+
+    /**
+     * Teste le fallback de la méthode get d'un détail
+     */
+    public function testGetOneFallback()
+    {
+        $this->repository->getMockController()->getOne = function () {
+            throw new \Exception('');
+        };
+
+        $this->exception(function () {
+            $this->newTestedInstance($this->repository, $this->router);
+            $this->testedInstance->get($this->request, $this->response, ['typeId' => 99]);
+        })->isInstanceOf('\Exception');
+    }
+
+    /**
+     * Teste la méthode get d'une liste trouvée
+     */
+    public function testGetListFound()
+    {
+        $this->request->getMockController()->getQueryParams = [];
+        $this->repository->getMockController()->getList = [
+            42 => $this->entite,
+        ];
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->get($this->request, $this->response, []);
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(200);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(200)
+            ->string['status']->isIdenticalTo('success')
+            ->string['message']->isIdenticalTo('')
+            //->array['data']->hasSize(1) // TODO: l'asserter atoum en sucre syntaxique est buggé, faire un ticket
+        ;
+        $this->array($data['data'][0])->hasKey('id');
+    }
+
+    /**
+     * Teste la méthode get d'une liste non trouvée
+     */
+    public function testGetListNotFound()
+    {
+        $this->request->getMockController()->getQueryParams = [];
+        $this->repository->getMockController()->getList = function () {
+            throw new \UnexpectedValueException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->get($this->request, $this->response, []);
+
+        $this->assertSuccessEmpty($response);
+    }
+
+    /**
+     * Teste le fallback de la méthode get d'une liste
+     */
+    public function testGetListFallback()
+    {
+        $this->request->getMockController()->getQueryParams = [];
+        $this->repository->getMockController()->getList = function () {
+            throw new \Exception('');
+        };
+
+        $this->exception(function () {
+            $this->newTestedInstance($this->repository, $this->router);
+            $this->testedInstance->get($this->request, $this->response, []);
+        })->isInstanceOf('\Exception');
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * Teste la méthode post d'un json mal formé
+     */
+    public function testPostJsonBadFormat()
+    {
+        // Le framework fait du traitement, un mauvais json est simplement null
+        $this->request->getMockController()->getParsedBody = null;
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+
+        $this->assertError($response, 400);
+    }
+
+    /**
+     * Teste la méthode post avec un argument de body manquant
+     */
+    public function testPostMissingRequiredArg()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->postOne = function () {
+            throw new \LibertAPI\Tools\Exceptions\MissingArgumentException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+
+        $this->assertError($response, 412);
+    }
+
+    /**
+     * Teste la méthode post avec un argument de body incohérent
+     */
+    public function testPostBadDomain()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->postOne = function () {
+            throw new \DomainException('Status doit être un int');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+
+        $this->assertError($response, 412);
+    }
+
+    /**
+     * Teste la méthode post Ok
+     */
+    public function testPostOk()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->router->getMockController()->pathFor = '';
+        $this->repository->getMockController()->postOne = 42;
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(201);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(201)
+            ->string['status']->isIdenticalTo('success')
+            ->string['message']->isIdenticalTo('')
+            ->array['data']->isNotEmpty()
+        ;
+    }
+
+    /**
+     * Teste le fallback de la méthode post
+     */
+    public function testPostFallback()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->postOne = function () {
+            throw new \Exception('');
+        };
+
+        $this->exception(function () {
+            $this->newTestedInstance($this->repository, $this->router);
+            $this->testedInstance->post($this->request, $this->response, []);
+        })->isInstanceOf('\Exception');
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * Teste la méthode put d'un json mal formé
+     */
+    public function testPutJsonBadFormat()
+    {
+        // Le framework fait du traitement, un mauvais json est simplement null
+        $this->request->getMockController()->getParsedBody = null;
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
+
+        $this->assertError($response, 400);
+    }
+
+    /**
+     * Teste la méthode put avec un détail non trouvé (id en Bad domaine)
+     */
+    public function testPutNotFound()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = function () {
+            throw new \DomainException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
+
+        $this->boolean($response->isNotFound())->isTrue();
+    }
+
+    /**
+     * Teste le fallback de la méthode getOne du put
+     */
+    public function testPutGetOneFallback()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = function () {
+            throw new \LogicException('');
+        };
+
+        $this->exception(function () {
+            $this->newTestedInstance($this->repository, $this->router);
+            $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
+        })->isInstanceOf('\Exception');
+    }
+
+    /**
+     * Teste la méthode put avec un argument de body manquant
+     */
+    public function testPutMissingRequiredArg()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = $this->entite;
+
+        $this->repository->getMockController()->putOne = function () {
+            throw new \LibertAPI\Tools\Exceptions\MissingArgumentException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
+
+        $this->assertError($response, 412);
+    }
+
+    /**
+     * Teste la méthode put avec un argument de body incohérent
+     */
+    public function testPutBadDomain()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = $this->entite;
+        $this->repository->getMockController()->putOne = function () {
+            throw new \DomainException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
+
+        $this->assertError($response, 412);
+    }
+
+    /**
+     * Teste le fallback de la méthode putOne du put
+     */
+    public function testPutPutOneFallback()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = $this->entite;
+        $this->repository->getMockController()->putOne = function () {
+            throw new \LogicException('');
+        };
+
+        $this->exception(function () {
+            $this->newTestedInstance($this->repository, $this->router);
+            $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
+        })->isInstanceOf('\Exception');
+    }
+
+    /**
+     * Teste la méthode put Ok
+     */
+    public function testPutOk()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = $this->entite;
+        $this->repository->getMockController()->putOne = '';
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
+
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(204);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(204)
+            ->string['status']->isIdenticalTo('success')
+            ->string['message']->isIdenticalTo('')
+            ->string['data']->isIdenticalTo('')
+        ;
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * Teste la méthode delete avec un détail non trouvé (id en Bad domaine)
+     */
+    public function testDeleteNotFound()
+    {
+        $this->repository->getMockController()->getOne = function () {
+            throw new \DomainException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
+
+        $this->boolean($response->isNotFound())->isTrue();
+    }
+
+    /**
+     * Teste le fallback de la méthode delete
+     */
+    public function testDeleteFallback()
+    {
+        $this->repository->getMockController()->getOne = function () {
+            throw new \LogicException('');
+        };
+
+        $this->exception(function () {
+            $this->newTestedInstance($this->repository, $this->router);
+            $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
+        })->isInstanceOf('\Exception');
+    }
+
+    /**
+     * Teste la méthode delete Ok
+     */
+    public function testDeleteOk()
+    {
+        $this->repository->getMockController()->getOne = $this->entite;
+        $this->newTestedInstance($this->repository, $this->router);
+        $response = $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(200);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(200)
+            ->string['status']->isIdenticalTo('success')
+            ->string['message']->isIdenticalTo('')
+            ->array['data']->isNotEmpty()
+        ;
+    }
+}

--- a/Tests/Units/Absence/Type/TypeController.php
+++ b/Tests/Units/Absence/Type/TypeController.php
@@ -9,28 +9,33 @@ namespace LibertAPI\Tests\Units\Absence\Type;
  *
  * @since 0.5
  */
-final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AController
+final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestController
 {
     /**
      * @var \LibertAPI\Tools\Libraries\ARepository Mock du repository associé
      */
-    private $repository;
+    protected $repository;
 
     /**
      * @var \LibertAPI\Tools\Libraries\AEntite Mock de l'entité associée
      */
-    private $entite;
+    protected $entite;
 
     /**
-     * Init des tests
+     * {@inheritdoc}
      */
-    public function beforeTestMethod($method)
+    protected function initRepository()
     {
-        parent::beforeTestMethod($method);
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\LibertAPI\Absence\Type\TypeRepository();
-        $this->mockGenerator->orphanize('__construct');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initEntite()
+    {
         $this->entite = new \LibertAPI\Absence\Type\TypeEntite([
             'id' => 42,
             'type' => 'thieft',
@@ -39,110 +44,14 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         ]);
     }
 
-    /*************************************************
-     * GET
-     *************************************************/
-
-    /**
-     * Teste la méthode get d'un détail trouvé
-     */
-    public function testGetOneFound()
+    protected function getOne()
     {
-        $this->repository->getMockController()->getOne = $this->entite;
-        $this->newTestedInstance($this->repository, $this->router);
-        $response = $this->testedInstance->get($this->request, $this->response, ['typeId' => 99]);
-        $data = $this->getJsonDecoded($response->getBody());
-
-        $this->integer($response->getStatusCode())->isIdenticalTo(200);
-        $this->array($data)
-            ->integer['code']->isIdenticalTo(200)
-            ->string['status']->isIdenticalTo('success')
-            ->string['message']->isIdenticalTo('')
-            ->array['data']->isNotEmpty()
-        ;
+        return $this->testedInstance->get($this->request, $this->response, ['typeId' => 99]);
     }
 
-    /**
-     * Teste la méthode get d'un détail non trouvé
-     */
-    public function testGetOneNotFound()
+    protected function getList()
     {
-        $this->repository->getMockController()->getOne = function () {
-            throw new \DomainException('');
-        };
-        $this->newTestedInstance($this->repository, $this->router);
-        $response = $this->testedInstance->get($this->request, $this->response, ['typeId' => 99]);
-
-        $this->assertError($response, 404);
-    }
-
-    /**
-     * Teste le fallback de la méthode get d'un détail
-     */
-    public function testGetOneFallback()
-    {
-        $this->repository->getMockController()->getOne = function () {
-            throw new \Exception('');
-        };
-
-        $this->exception(function () {
-            $this->newTestedInstance($this->repository, $this->router);
-            $this->testedInstance->get($this->request, $this->response, ['typeId' => 99]);
-        })->isInstanceOf('\Exception');
-    }
-
-    /**
-     * Teste la méthode get d'une liste trouvée
-     */
-    public function testGetListFound()
-    {
-        $this->request->getMockController()->getQueryParams = [];
-        $this->repository->getMockController()->getList = [
-            42 => $this->entite,
-        ];
-        $this->newTestedInstance($this->repository, $this->router);
-        $response = $this->testedInstance->get($this->request, $this->response, []);
-        $data = $this->getJsonDecoded($response->getBody());
-
-        $this->integer($response->getStatusCode())->isIdenticalTo(200);
-        $this->array($data)
-            ->integer['code']->isIdenticalTo(200)
-            ->string['status']->isIdenticalTo('success')
-            ->string['message']->isIdenticalTo('')
-            //->array['data']->hasSize(1) // TODO: l'asserter atoum en sucre syntaxique est buggé, faire un ticket
-        ;
-        $this->array($data['data'][0])->hasKey('id');
-    }
-
-    /**
-     * Teste la méthode get d'une liste non trouvée
-     */
-    public function testGetListNotFound()
-    {
-        $this->request->getMockController()->getQueryParams = [];
-        $this->repository->getMockController()->getList = function () {
-            throw new \UnexpectedValueException('');
-        };
-        $this->newTestedInstance($this->repository, $this->router);
-        $response = $this->testedInstance->get($this->request, $this->response, []);
-
-        $this->assertSuccessEmpty($response);
-    }
-
-    /**
-     * Teste le fallback de la méthode get d'une liste
-     */
-    public function testGetListFallback()
-    {
-        $this->request->getMockController()->getQueryParams = [];
-        $this->repository->getMockController()->getList = function () {
-            throw new \Exception('');
-        };
-
-        $this->exception(function () {
-            $this->newTestedInstance($this->repository, $this->router);
-            $this->testedInstance->get($this->request, $this->response, []);
-        })->isInstanceOf('\Exception');
+        return $this->testedInstance->get($this->request, $this->response, []);
     }
 
     /*************************************************
@@ -156,10 +65,10 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
     {
         // Le framework fait du traitement, un mauvais json est simplement null
         $this->request->getMockController()->getParsedBody = null;
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->post($this->request, $this->response, []);
 
-        $this->assertError($response, 400);
+        $this->assertFail($response, 400);
     }
 
     /**
@@ -171,10 +80,10 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         $this->repository->getMockController()->postOne = function () {
             throw new \LibertAPI\Tools\Exceptions\MissingArgumentException('');
         };
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->post($this->request, $this->response, []);
 
-        $this->assertError($response, 412);
+        $this->assertFail($response, 412);
     }
 
     /**
@@ -186,10 +95,10 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         $this->repository->getMockController()->postOne = function () {
             throw new \DomainException('Status doit être un int');
         };
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->post($this->request, $this->response, []);
 
-        $this->assertError($response, 412);
+        $this->assertFail($response, 412);
     }
 
     /**
@@ -200,7 +109,7 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         $this->request->getMockController()->getParsedBody = [];
         $this->router->getMockController()->pathFor = '';
         $this->repository->getMockController()->postOne = 42;
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->post($this->request, $this->response, []);
         $data = $this->getJsonDecoded($response->getBody());
 
@@ -208,7 +117,6 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         $this->array($data)
             ->integer['code']->isIdenticalTo(201)
             ->string['status']->isIdenticalTo('success')
-            ->string['message']->isIdenticalTo('')
             ->array['data']->isNotEmpty()
         ;
     }
@@ -223,10 +131,11 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
             throw new \Exception('');
         };
 
-        $this->exception(function () {
-            $this->newTestedInstance($this->repository, $this->router);
-            $this->testedInstance->post($this->request, $this->response, []);
-        })->isInstanceOf('\Exception');
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+
+        $this->assertError($response);
     }
 
     /*************************************************
@@ -240,10 +149,10 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
     {
         // Le framework fait du traitement, un mauvais json est simplement null
         $this->request->getMockController()->getParsedBody = null;
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
 
-        $this->assertError($response, 400);
+        $this->assertFail($response, 400);
     }
 
     /**
@@ -255,7 +164,7 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         $this->repository->getMockController()->getOne = function () {
             throw new \DomainException('');
         };
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
 
         $this->boolean($response->isNotFound())->isTrue();
@@ -272,7 +181,7 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         };
 
         $this->exception(function () {
-            $this->newTestedInstance($this->repository, $this->router);
+            $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
             $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
         })->isInstanceOf('\Exception');
     }
@@ -288,10 +197,10 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         $this->repository->getMockController()->putOne = function () {
             throw new \LibertAPI\Tools\Exceptions\MissingArgumentException('');
         };
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
 
-        $this->assertError($response, 412);
+        $this->assertFail($response, 412);
     }
 
     /**
@@ -304,10 +213,10 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         $this->repository->getMockController()->putOne = function () {
             throw new \DomainException('');
         };
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
 
-        $this->assertError($response, 412);
+        $this->assertFail($response, 412);
     }
 
     /**
@@ -322,7 +231,7 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         };
 
         $this->exception(function () {
-            $this->newTestedInstance($this->repository, $this->router);
+            $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
             $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
         })->isInstanceOf('\Exception');
     }
@@ -335,7 +244,7 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         $this->request->getMockController()->getParsedBody = [];
         $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = '';
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
 
         $data = $this->getJsonDecoded($response->getBody());
@@ -361,7 +270,7 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         $this->repository->getMockController()->getOne = function () {
             throw new \DomainException('');
         };
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
 
         $this->boolean($response->isNotFound())->isTrue();
@@ -377,7 +286,7 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
         };
 
         $this->exception(function () {
-            $this->newTestedInstance($this->repository, $this->router);
+            $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
             $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
         })->isInstanceOf('\Exception');
     }
@@ -388,7 +297,7 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\AContr
     public function testDeleteOk()
     {
         $this->repository->getMockController()->getOne = $this->entite;
-        $this->newTestedInstance($this->repository, $this->router);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
         $data = $this->getJsonDecoded($response->getBody());
 

--- a/Tests/Units/Absence/Type/TypeController.php
+++ b/Tests/Units/Absence/Type/TypeController.php
@@ -179,11 +179,10 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
         $this->repository->getMockController()->getOne = function () {
             throw new \LogicException('');
         };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
-        $this->exception(function () {
-            $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-            $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
-        })->isInstanceOf('\Exception');
+        $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
+        $this->assertError($response);
     }
 
     /**
@@ -229,11 +228,10 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
         $this->repository->getMockController()->putOne = function () {
             throw new \LogicException('');
         };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
-        $this->exception(function () {
-            $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-            $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
-        })->isInstanceOf('\Exception');
+        $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
+        $this->assertError($response);
     }
 
     /**
@@ -253,7 +251,6 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
         $this->array($data)
             ->integer['code']->isIdenticalTo(204)
             ->string['status']->isIdenticalTo('success')
-            ->string['message']->isIdenticalTo('')
             ->string['data']->isIdenticalTo('')
         ;
     }

--- a/Tests/Units/Absence/Type/TypeDao.php
+++ b/Tests/Units/Absence/Type/TypeDao.php
@@ -1,17 +1,15 @@
 <?php
-namespace LibertAPI\Tests\Units\Planning;
-
-use LibertAPI\Planning\PlanningDao as _Dao;
+namespace LibertAPI\Tests\Units\Absence\Type;
 
 /**
- * Classe de test du DAO de planning
+ * Classe de test du DAO de type d'absence
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.1
+ * @since 0.5
  */
-final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
+final class TypeDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
 {
     /*************************************************
      * GET
@@ -23,9 +21,9 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     public function testGetByIdNotFound()
     {
         $this->calling($this->result)->fetch = [];
-        $dao = new _Dao($this->connector);
+        $this->newTestedInstance($this->connector);
 
-        $get = $dao->getById(99);
+        $get = $this->testedInstance->getById(99);
 
         $this->array($get)->isEmpty();
     }
@@ -36,9 +34,9 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     public function testGetByIdFound()
     {
         $this->calling($this->result)->fetch = ['a'];
-        $dao = new _Dao($this->connector);
+        $this->newTestedInstance($this->connector);
 
-        $get = $dao->getById(99);
+        $get = $this->testedInstance->getById(99);
 
         $this->array($get)->isNotEmpty();
     }
@@ -49,9 +47,9 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     public function testGetListNotFound()
     {
         $this->calling($this->result)->fetchAll = [];
-        $dao = new _Dao($this->connector);
+        $this->newTestedInstance($this->connector);
 
-        $get = $dao->getList([]);
+        $get = $this->testedInstance->getList([]);
 
         $this->array($get)->isEmpty();
     }
@@ -62,9 +60,9 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     public function testGetListFound()
     {
         $this->calling($this->result)->fetchAll = [['a']];
-        $dao = new _Dao($this->connector);
+        $this->newTestedInstance($this->connector);
 
-        $get = $dao->getList([]);
+        $get = $this->testedInstance->getList([]);
 
         $this->array($get[0])->isNotEmpty();
     }
@@ -79,11 +77,12 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     public function testPostOk()
     {
         $this->calling($this->connector)->lastInsertId = 314;
-        $dao = new _Dao($this->connector);
+        $this->newTestedInstance($this->connector);
 
-        $postId = $dao->post([
-            'name' => 'name',
-            'status' => 59,
+        $postId = $this->testedInstance->post([
+            'type' => 'type',
+            'libelle' => 'libelle',
+            'libelleCourt' => 'libelleCourt',
         ]);
 
         $this->integer($postId)->isIdenticalTo(314);
@@ -98,11 +97,12 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      */
     public function testPutOk()
     {
-        $dao = new _Dao($this->connector);
+        $this->newTestedInstance($this->connector);
 
-        $put = $dao->put([
-            'name' => 'name',
-            'status' => 59,
+        $put = $this->testedInstance->put([
+            'type' => 'type',
+            'libelle' => 'libelle',
+            'libelleCourt' => 'libelleCourt',
         ], 12);
 
         $this->variable($put)->isNull();
@@ -118,9 +118,9 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     public function testDeleteOk()
     {
         $this->calling($this->result)->rowCount = 1;
-        $dao = new _Dao($this->connector);
+        $this->newTestedInstance($this->connector);
 
-        $res = $dao->delete(7);
+        $res = $this->testedInstance->delete(7);
 
         $this->integer($res)->isIdenticalTo(1);
     }

--- a/Tests/Units/Absence/Type/TypeDao.php
+++ b/Tests/Units/Absence/Type/TypeDao.php
@@ -12,62 +12,6 @@ namespace LibertAPI\Tests\Units\Absence\Type;
 final class TypeDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
 {
     /*************************************************
-     * GET
-     *************************************************/
-
-    /**
-     * Teste la méthode getById avec un id non trouvé
-     */
-    public function testGetByIdNotFound()
-    {
-        $this->calling($this->result)->fetch = [];
-        $this->newTestedInstance($this->connector);
-
-        $get = $this->testedInstance->getById(99);
-
-        $this->array($get)->isEmpty();
-    }
-
-    /**
-     * Teste la méthode getById avec un id trouvé
-     */
-    public function testGetByIdFound()
-    {
-        $this->calling($this->result)->fetch = ['a'];
-        $this->newTestedInstance($this->connector);
-
-        $get = $this->testedInstance->getById(99);
-
-        $this->array($get)->isNotEmpty();
-    }
-
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->calling($this->result)->fetchAll = [];
-        $this->newTestedInstance($this->connector);
-
-        $get = $this->testedInstance->getList([]);
-
-        $this->array($get)->isEmpty();
-    }
-
-    /**
-     * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->calling($this->result)->fetchAll = [['a']];
-        $this->newTestedInstance($this->connector);
-
-        $get = $this->testedInstance->getList([]);
-
-        $this->array($get[0])->isNotEmpty();
-    }
-
-    /*************************************************
      * POST
      *************************************************/
 
@@ -106,22 +50,5 @@ final class TypeDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         ], 12);
 
         $this->variable($put)->isNull();
-    }
-
-    /*************************************************
-     * DELETE
-     *************************************************/
-
-    /**
-     * Teste la méthode delete quand tout est ok
-     */
-    public function testDeleteOk()
-    {
-        $this->calling($this->result)->rowCount = 1;
-        $this->newTestedInstance($this->connector);
-
-        $res = $this->testedInstance->delete(7);
-
-        $this->integer($res)->isIdenticalTo(1);
     }
 }

--- a/Tests/Units/Absence/Type/TypeEntite.php
+++ b/Tests/Units/Absence/Type/TypeEntite.php
@@ -1,0 +1,78 @@
+<?php
+namespace LibertAPI\Tests\Units\Absence\Type;
+
+use \LibertAPI\Planning\PlanningEntite as _Entite;
+
+/**
+ * Classe de test du modèle de planning
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+final class TypeEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEntite
+{
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithId()
+    {
+        $id = 3;
+        $type = 'type';
+        $libelle = 'douze';
+
+        $this->newTestedInstance(['id' => $id, 'type' => $type, 'libelle' => $libelle]);
+
+        $this->assertConstructWithId($this->testedInstance, $id);
+        $this->string($this->testedInstance->getType())->isIdenticalTo($type);
+        $this->string($this->testedInstance->getLibelle())->isIdenticalTo($libelle);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithoutId()
+    {
+        $this->newTestedInstance(['name' => 'name', 'status' => 'status']);
+
+        $this->variable($this->testedInstance->getId())->isNull();
+    }
+
+    /**
+     * Teste la méthode populate avec un mauvais domaine de définition
+     */
+    public function testPopulateBadDomain()
+    {
+        $this->newTestedInstance([]);
+        $data = ['type' => '', 'libelle' => 45, 'libelleCourt' => 'non'];
+
+        $this->exception(function () use ($data) {
+            $this->testedInstance->populate($data);
+        })->isInstanceOf('\DomainException');
+    }
+
+    /**
+     * Teste la méthode populate avec ok
+     */
+    public function testPopulateOk()
+    {
+        $this->newTestedInstance([]);
+        $data = ['type' => 'a', 'libelle' => '45', 'libelleCourt' => 'oui'];
+
+        $this->testedInstance->populate($data);
+
+        $this->string($this->testedInstance->getType())->isIdenticalTo($data['type']);
+        $this->string($this->testedInstance->getLibelle())->isIdenticalTo($data['libelle']);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testReset()
+    {
+        $this->newTestedInstance(['id' => 3, 'name' => 'name', 'status' => 'status']);
+
+        $this->assertReset($this->testedInstance);
+    }
+}

--- a/Tests/Units/Absence/Type/TypeRepository.php
+++ b/Tests/Units/Absence/Type/TypeRepository.php
@@ -198,7 +198,7 @@ final class TypeRepository extends \Atoum
         $this->newTestedInstance($this->dao);
 
         $this->exception(function () {
-            $this->testedInstance->deleteOne(new \mock\LibertAPI\Planning\PlanningEntite([]));
+            $this->testedInstance->deleteOne(new \LibertAPI\Absence\Type\TypeEntite([]));
         })->isInstanceOf('\LogicException');
 
     }
@@ -210,7 +210,7 @@ final class TypeRepository extends \Atoum
     {
         $this->dao->getMockController()->delete = 4;
         $this->newTestedInstance($this->dao);
-        $entite = new \mock\LibertAPI\Planning\PlanningEntite([]);
+        $entite = new \LibertAPI\Absence\Type\TypeEntite([]);
 
         $this->variable($this->testedInstance->deleteOne($entite))->isNull();
     }

--- a/Tests/Units/Absence/Type/TypeRepository.php
+++ b/Tests/Units/Absence/Type/TypeRepository.php
@@ -23,6 +23,7 @@ final class TypeRepository extends \Atoum
 
     public function beforeTestMethod($method)
     {
+        parent::beforeTestMethod($method);
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\LibertAPI\Absence\Type\TypeDao();

--- a/Tests/Units/Absence/Type/TypeRepository.php
+++ b/Tests/Units/Absence/Type/TypeRepository.php
@@ -1,0 +1,217 @@
+<?php
+namespace LibertAPI\Tests\Units\Absence\Type;
+
+/**
+ * Classe de test du repository de planning
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+final class TypeRepository extends \Atoum
+{
+    /**
+     * @var \LibertAPI\Absence\Type\TypeDao Mock du DAO du planning
+     */
+    private $dao;
+
+    /**
+     * @var \LibertAPI\Absence\Type\TypeEntite Mock de l'Entité de planning
+     */
+    private $entite;
+
+    public function beforeTestMethod($method)
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $this->dao = new \mock\LibertAPI\Absence\Type\TypeDao();
+        $this->mockGenerator->orphanize('__construct');
+        $this->entite = new \LibertAPI\Absence\Type\TypeEntite([
+            'id' => 42,
+            'type' => 'thieft',
+            'libelle' => 'GTA',
+            'libelleCourt' => 'vice'
+        ]);
+    }
+
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * Teste la méthode getOne avec un id non trouvé
+     */
+    public function testGetOneNotFound()
+    {
+        $this->dao->getMockController()->getById = [];
+        $this->newTestedInstance($this->dao);
+        $this->exception(function () {
+            $this->testedInstance->getOne(99);
+        })->isInstanceOf('\DomainException');
+    }
+
+    /**
+     * Teste la méthode getOne avec un id trouvé
+     */
+    public function testGetOneFound()
+    {
+        $this->dao->getMockController()->getById = [
+            'ta_id' => 42,
+            'ta_type' => 'aventure',
+            'ta_libelle' => 'AS',
+            'ta_short_libelle' => 'creed',
+        ];
+        $this->newTestedInstance($this->dao);
+        $entite = $this->testedInstance->getOne(42);
+
+        $this->object($entite)->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
+        $this->integer($entite->getId())->isIdenticalTo(42);
+    }
+
+    /**
+     * Teste la méthode getList avec des critères non pertinents
+     */
+    public function testGetListNotFound()
+    {
+        $this->dao->getMockController()->getList = [];
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->getList([]);
+        })->isInstanceOf('\UnexpectedValueException');
+    }
+
+    /**
+     * Teste la méthode getList avec des critères pertinents
+     */
+    public function testGetListFound()
+    {
+        $this->dao->getMockController()->getList = [[
+            'ta_id' => 42,
+            'ta_type' => 'aventure',
+            'ta_libelle' => 'AS',
+            'ta_short_libelle' => 'creed',
+        ]];
+        $this->newTestedInstance($this->dao);
+        $entites = $this->testedInstance->getList([]);
+
+        $this->array($entites)->hasKey(42);
+        $this->object($entites[42])->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * Teste la méthode postOne avec un champ manquant
+     */
+    public function testPostOneMissingArg()
+    {
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->postOne(['name' => 'bob'], new \LibertAPI\Absence\Type\TypeEntite([]));
+        })->isInstanceOf('\LibertAPI\Tools\Exceptions\MissingArgumentException');
+    }
+
+    /**
+     * Teste la méthode postOne avec un champ incohérent
+     */
+    public function testPostOneBadDomain()
+    {
+        $this->newTestedInstance($this->dao);
+        $entite = new \LibertAPI\Absence\Type\TypeEntite([]);
+
+        $this->exception(function () use ($entite) {
+            $this->testedInstance->postOne(['type' => '', 'libelle' => 'Roger', 'libelleCourt' => 'Maverick'], $entite);
+        })->isInstanceOf('\DomainException');
+    }
+
+    /**
+     * Teste la méthode postOne quand tout est ok
+     */
+    public function testPostOneOk()
+    {
+        $this->dao->getMockController()->post = 3;
+        $this->newTestedInstance($this->dao);
+
+        $post = $this->testedInstance->postOne(['type' => 'Holly', 'libelle' => 'Roger', 'libelleCourt' => 'Maverick'], $this->entite);
+
+        $this->integer($post);
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * Teste la méthode putOne avec un champ manquant
+     */
+    public function testPutOneMissingArgument()
+    {
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->putOne(['libelle' => 'Roger', 'libelleCourt' => 'Maverick'], new \LibertAPI\Absence\Type\TypeEntite([]));
+        })->isInstanceOf('\LibertAPI\Tools\Exceptions\MissingArgumentException');
+    }
+
+    /**
+     * Teste la méthode putOne avec un champ incohérent
+     */
+    public function testPutOneBadDomain()
+    {
+        $this->newTestedInstance($this->dao);
+        $entite = new \LibertAPI\Absence\Type\TypeEntite([]);
+
+        $this->exception(function () use ($entite) {
+            $this->testedInstance->putOne(['type' => '', 'libelle' => 'Roger', 'libelleCourt' => 'Maverick'], $entite);
+        })->isInstanceOf('\DomainException');
+    }
+
+    /**
+     * Teste la méthode putOne tout ok
+     */
+    public function testPutOneOk()
+    {
+        $this->newTestedInstance($this->dao);
+
+        $result = $this->testedInstance->putOne(['type' => 'Holly', 'libelle' => 'Roger', 'libelleCourt' => 'Maverick'], $this->entite);
+
+        $this->variable($result)->isNull();
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * Teste le fallback de la méthode deleteOne
+     */
+    public function testDeleteFallback()
+    {
+        $this->dao->getMockController()->delete = function () {
+            throw new \LogicException('');
+        };
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->deleteOne(new \mock\LibertAPI\Planning\PlanningEntite([]));
+        })->isInstanceOf('\LogicException');
+
+    }
+
+    /**
+     * Teste la méthode deleteOne tout ok
+     */
+    public function testDeleteOk()
+    {
+        $this->dao->getMockController()->delete = 4;
+        $this->newTestedInstance($this->dao);
+        $entite = new \mock\LibertAPI\Planning\PlanningEntite([]);
+
+        $this->variable($this->testedInstance->deleteOne($entite))->isNull();
+    }
+}

--- a/Tests/Units/Authentification/AuthentificationController.php
+++ b/Tests/Units/Authentification/AuthentificationController.php
@@ -42,7 +42,7 @@ final class AuthentificationController extends \LibertAPI\Tests\Units\Tools\Libr
         $this->request->getMockController()->getHeaderLine = 'NotBasic';
         $this->newTestedInstance($this->repository, $this->router);
 
-        $response = $this->testedInstance->get($this->request, $this->response);
+        $response = $this->testedInstance->get($this->request, $this->response, []);
 
         $this->assertFail($response, 400);
     }
@@ -60,7 +60,8 @@ final class AuthentificationController extends \LibertAPI\Tests\Units\Tools\Libr
 
         $response = $this->testedInstance->get(
             $this->request,
-            $this->response
+            $this->response,
+            []
         );
 
         $this->assertFail($response, 404);
@@ -78,7 +79,7 @@ final class AuthentificationController extends \LibertAPI\Tests\Units\Tools\Libr
         $this->request->getMockController()->getHeaderLine = 'Basic QWxhZGRpbjpPcGVuU2VzYW1l';
         $this->newTestedInstance($this->repository, $this->router);
 
-        $response = $this->testedInstance->get($this->request, $this->response);
+        $response = $this->testedInstance->get($this->request, $this->response, []);
         $data = $this->getJsonDecoded($response->getBody());
 
         $this->integer($response->getStatusCode())->isIdenticalTo(200);

--- a/Tests/Units/Journal/JournalDao.php
+++ b/Tests/Units/Journal/JournalDao.php
@@ -16,15 +16,23 @@ final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      *************************************************/
 
     /**
-     * Teste la méthode getById
-     */
-    public function testGetById()
+    * Teste la méthode getById avec un id non trouvé
+    */
+    public function testGetByIdNotFound()
     {
-        $this->newTestedInstance($this->connector);
-
         $this->exception(function () {
-            $this->testedInstance->delete([]);
-        })->isInstanceOf(\RuntimeException::class);
+            $this->newTestedInstance($this->connector)->getById(0);
+        });
+    }
+
+    /**
+    * Teste la méthode getById avec un id trouvé
+    */
+    public function testGetByIdFound()
+    {
+        $this->exception(function () {
+            $this->newTestedInstance($this->connector)->getById(0);
+        });
     }
 
     /**

--- a/Tests/Units/Planning/Creneau/CreneauDao.php
+++ b/Tests/Units/Planning/Creneau/CreneauDao.php
@@ -17,57 +17,6 @@ final class CreneauDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      * GET
      *************************************************/
 
-    /**
-     * Teste la méthode getById avec un id non trouvé
-     */
-    public function testGetByIdNotFound()
-    {
-        $this->calling($this->result)->fetch = [];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getById(99);
-
-        $this->array($get)->isEmpty();
-    }
-
-    /**
-     * Teste la méthode getById avec un id trouvé
-     */
-    public function testGetByIdFound()
-    {
-        $this->calling($this->result)->fetch = ['a'];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getById(99);
-
-        $this->array($get)->isNotEmpty();
-    }
-
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->calling($this->result)->fetchAll = [];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getList([]);
-
-        $this->array($get)->isEmpty();
-    }
-
-    /**
-    * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->calling($this->result)->fetchAll = [['a']];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getList([]);
-
-        $this->array($get[0])->isNotEmpty();
-    }
 
     /*************************************************
      * POST
@@ -114,5 +63,18 @@ final class CreneauDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         ], 22);
 
         $this->variable($put)->isNull();
+    }
+
+    /**
+     * Teste la méthode delete quand tout est ok
+     */
+    public function testDeleteOk()
+    {
+        $this->calling($this->result)->rowCount = 1;
+        $this->newTestedInstance($this->connector);
+
+        $res = $this->testedInstance->delete(7);
+
+        $this->variable($res)->isNull();
     }
 }

--- a/Tests/Units/Planning/PlanningController.php
+++ b/Tests/Units/Planning/PlanningController.php
@@ -145,7 +145,7 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
-        $response = $this->testedInstance->post($this->request, $this->response);
+        $response = $this->testedInstance->post($this->request, $this->response , []);
 
         $this->assertError($response);
     }

--- a/Tests/Units/Planning/PlanningController.php
+++ b/Tests/Units/Planning/PlanningController.php
@@ -76,7 +76,7 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         $this->request->getMockController()->getParsedBody = null;
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
-        $response = $this->testedInstance->post($this->request, $this->response);
+        $response = $this->testedInstance->post($this->request, $this->response, []);
 
         $this->assertFail($response, 400);
     }
@@ -92,7 +92,7 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
-        $response = $this->testedInstance->post($this->request, $this->response);
+        $response = $this->testedInstance->post($this->request, $this->response, []);
 
         $this->assertFail($response, 412);
     }
@@ -108,7 +108,7 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
-        $response = $this->testedInstance->post($this->request, $this->response);
+        $response = $this->testedInstance->post($this->request, $this->response, []);
 
         $this->assertFail($response, 412);
     }
@@ -123,7 +123,7 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         $this->repository->getMockController()->postOne = 42;
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
-        $response = $this->testedInstance->post($this->request, $this->response);
+        $response = $this->testedInstance->post($this->request, $this->response, []);
         $data = $this->getJsonDecoded($response->getBody());
 
         $this->integer($response->getStatusCode())->isIdenticalTo(201);

--- a/Tests/Units/Planning/PlanningController.php
+++ b/Tests/Units/Planning/PlanningController.php
@@ -145,7 +145,7 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
-        $response = $this->testedInstance->post($this->request, $this->response , []);
+        $response = $this->testedInstance->post($this->request, $this->response, []);
 
         $this->assertError($response);
     }

--- a/Tests/Units/Planning/PlanningDao.php
+++ b/Tests/Units/Planning/PlanningDao.php
@@ -17,57 +17,6 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      * GET
      *************************************************/
 
-    /**
-     * Teste la méthode getById avec un id non trouvé
-     */
-    public function testGetByIdNotFound()
-    {
-        $this->calling($this->result)->fetch = [];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getById(99);
-
-        $this->array($get)->isEmpty();
-    }
-
-    /**
-     * Teste la méthode getById avec un id trouvé
-     */
-    public function testGetByIdFound()
-    {
-        $this->calling($this->result)->fetch = ['a'];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getById(99);
-
-        $this->array($get)->isNotEmpty();
-    }
-
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->calling($this->result)->fetchAll = [];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getList([]);
-
-        $this->array($get)->isEmpty();
-    }
-
-    /**
-     * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->calling($this->result)->fetchAll = [['a']];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getList([]);
-
-        $this->array($get[0])->isNotEmpty();
-    }
 
     /*************************************************
      * POST
@@ -106,22 +55,5 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         ], 12);
 
         $this->variable($put)->isNull();
-    }
-
-    /*************************************************
-     * DELETE
-     *************************************************/
-
-    /**
-     * Teste la méthode delete quand tout est ok
-     */
-    public function testDeleteOk()
-    {
-        $this->calling($this->result)->rowCount = 1;
-        $dao = new _Dao($this->connector);
-
-        $res = $dao->delete(7);
-
-        $this->integer($res)->isIdenticalTo(1);
     }
 }

--- a/Tests/Units/Tools/Libraries/ADao.php
+++ b/Tests/Units/Tools/Libraries/ADao.php
@@ -47,4 +47,68 @@ abstract class ADao extends \Atoum
      */
     protected $result;
 
+    /**
+     * Teste la méthode getById avec un id non trouvé
+     */
+    public function testGetByIdNotFound()
+    {
+        $this->calling($this->result)->fetch = [];
+        $this->newTestedInstance($this->connector);
+
+        $get = $this->testedInstance->getById(99);
+
+        $this->array($get)->isEmpty();
+    }
+
+    /**
+     * Teste la méthode getById avec un id trouvé
+     */
+    public function testGetByIdFound()
+    {
+        $this->calling($this->result)->fetch = ['a'];
+        $this->newTestedInstance($this->connector);
+
+        $get = $this->testedInstance->getById(99);
+
+        $this->array($get)->isNotEmpty();
+    }
+
+    /**
+     * Teste la méthode getList avec des critères non pertinents
+     */
+    public function testGetListNotFound()
+    {
+        $this->calling($this->result)->fetchAll = [];
+        $this->newTestedInstance($this->connector);
+
+        $get = $this->testedInstance->getList([]);
+
+        $this->array($get)->isEmpty();
+    }
+
+    /**
+     * Teste la méthode getList avec des critères pertinents
+     */
+    public function testGetListFound()
+    {
+        $this->calling($this->result)->fetchAll = [['a']];
+        $this->newTestedInstance($this->connector);
+
+        $get = $this->testedInstance->getList([]);
+
+        $this->array($get[0])->isNotEmpty();
+    }
+
+    /**
+     * Teste la méthode delete quand tout est ok
+     */
+    public function testDeleteOk()
+    {
+        $this->calling($this->result)->rowCount = 1;
+        $this->newTestedInstance($this->connector);
+
+        $res = $this->testedInstance->delete(7);
+
+        $this->integer($res)->isIdenticalTo(1);
+    }
 }

--- a/Tests/Units/Utilisateur/UtilisateurDao.php
+++ b/Tests/Units/Utilisateur/UtilisateurDao.php
@@ -22,6 +22,9 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      */
     public function testGetByIdNotFound()
     {
+        $this->exception(function () {
+            $this->newTestedInstance($this->connector)->getById(0);
+        });
     }
 
     /**
@@ -29,12 +32,9 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      */
     public function testGetByIdFound()
     {
-    }
-
-    public function testGetById()
-    {
-        $dao = new _Dao($this->connector);
-        $this->variable($dao->getById(''))->isNull();
+        $this->exception(function () {
+            $this->newTestedInstance($this->connector)->getById(0);
+        });
     }
 
     /*************************************************

--- a/Tests/Units/Utilisateur/UtilisateurDao.php
+++ b/Tests/Units/Utilisateur/UtilisateurDao.php
@@ -17,36 +17,24 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      * GET
      *************************************************/
 
+    /**
+     * Teste la méthode getById avec un id non trouvé
+     */
+    public function testGetByIdNotFound()
+    {
+    }
+
+    /**
+     * Teste la méthode getById avec un id trouvé
+     */
+    public function testGetByIdFound()
+    {
+    }
+
     public function testGetById()
     {
         $dao = new _Dao($this->connector);
         $this->variable($dao->getById(''))->isNull();
-    }
-
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->calling($this->result)->fetchAll = [];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getList([]);
-
-        $this->array($get)->isEmpty();
-    }
-
-    /**
-     * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->calling($this->result)->fetchAll = [['a']];
-        $dao = new _Dao($this->connector);
-
-        $get = $dao->getList([]);
-
-        $this->array($get[0])->isNotEmpty();
     }
 
     /*************************************************
@@ -82,9 +70,16 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      * DELETE
      *************************************************/
 
-    public function testDelete()
-    {
-        $dao = new _Dao($this->connector);
-        $this->variable($dao->delete([]))->isNull();
-    }
+     /**
+      * Teste la méthode delete quand tout est ok
+      */
+     public function testDeleteOk()
+     {
+         $this->calling($this->result)->rowCount = 1;
+         $this->newTestedInstance($this->connector);
+
+         $res = $this->testedInstance->delete(7);
+
+         $this->variable($res)->isNull();
+     }
 }

--- a/Tests/Units/Utilisateur/UtilisateurDao.php
+++ b/Tests/Units/Utilisateur/UtilisateurDao.php
@@ -70,16 +70,16 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      * DELETE
      *************************************************/
 
-     /**
-      * Teste la méthode delete quand tout est ok
-      */
-     public function testDeleteOk()
-     {
-         $this->calling($this->result)->rowCount = 1;
-         $this->newTestedInstance($this->connector);
+    /**
+     * Teste la méthode delete quand tout est ok
+     */
+    public function testDeleteOk()
+    {
+        $this->calling($this->result)->rowCount = 1;
+        $this->newTestedInstance($this->connector);
 
-         $res = $this->testedInstance->delete(7);
+        $res = $this->testedInstance->delete(7);
 
-         $this->variable($res)->isNull();
-     }
+        $this->variable($res)->isNull();
+    }
 }

--- a/Tools/Interfaces/IDeletable.php
+++ b/Tools/Interfaces/IDeletable.php
@@ -18,5 +18,5 @@ interface IDeletable
      *
      * @return IResponse
      */
-   public function delete(IRequest $request, IResponse $response, array $routeArguments);
+    public function delete(IRequest $request, IResponse $response, array $routeArguments);
 }

--- a/Tools/Interfaces/IDeletable.php
+++ b/Tools/Interfaces/IDeletable.php
@@ -1,0 +1,22 @@
+<?php
+namespace LibertAPI\Tools\Interfaces;
+
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+
+/**
+ * Interface décrivant la consommation de l'ordre REST Delete
+ */
+interface IDeletable
+{
+    /**
+     * Execute l'ordre HTTP PUT
+     *
+     * @param IRequest $request Requête Http
+     * @param IResponse $response Réponse Http
+     * @param array $routeArguments Arguments de route
+     *
+     * @return IResponse
+     */
+   public function delete(IRequest $request, IResponse $response, array $routeArguments);
+}

--- a/Tools/Interfaces/IGetable.php
+++ b/Tools/Interfaces/IGetable.php
@@ -1,0 +1,22 @@
+<?php
+namespace LibertAPI\Tools\Interfaces;
+
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+
+/**
+ * Interface décrivant la consommation de l'ordre REST GET
+ */
+interface IGetable
+{
+    /**
+     * Execute l'ordre HTTP GET
+     *
+     * @param IRequest $request Requête Http
+     * @param IResponse $response Réponse Http
+     * @param array $routeArguments Arguments de route
+     *
+     * @return IResponse
+     */
+    public function get(IRequest $request, IResponse $response, array $routeArguments);
+}

--- a/Tools/Interfaces/IPostable.php
+++ b/Tools/Interfaces/IPostable.php
@@ -1,0 +1,22 @@
+<?php
+namespace LibertAPI\Tools\Interfaces;
+
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+
+/**
+ * Interface décrivant la consommation de l'ordre REST POST
+ */
+interface IPostable
+{
+    /**
+     * Execute l'ordre HTTP POST
+     *
+     * @param IRequest $request Requête Http
+     * @param IResponse $response Réponse Http
+     * @param array $routeArguments Arguments de route
+     *
+     * @return IResponse
+     */
+   public function post(IRequest $request, IResponse $response, array $routeArguments);
+}

--- a/Tools/Interfaces/IPostable.php
+++ b/Tools/Interfaces/IPostable.php
@@ -18,5 +18,5 @@ interface IPostable
      *
      * @return IResponse
      */
-   public function post(IRequest $request, IResponse $response, array $routeArguments);
+    public function post(IRequest $request, IResponse $response, array $routeArguments);
 }

--- a/Tools/Interfaces/IPutable.php
+++ b/Tools/Interfaces/IPutable.php
@@ -18,5 +18,5 @@ interface IPutable
      *
      * @return IResponse
      */
-   public function put(IRequest $request, IResponse $response, array $routeArguments);
+    public function put(IRequest $request, IResponse $response, array $routeArguments);
 }

--- a/Tools/Interfaces/IPutable.php
+++ b/Tools/Interfaces/IPutable.php
@@ -1,0 +1,22 @@
+<?php
+namespace LibertAPI\Tools\Interfaces;
+
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+
+/**
+ * Interface décrivant la consommation de l'ordre REST PUT
+ */
+interface IPutable
+{
+    /**
+     * Execute l'ordre HTTP PUT
+     *
+     * @param IRequest $request Requête Http
+     * @param IResponse $response Réponse Http
+     * @param array $routeArguments Arguments de route
+     *
+     * @return IResponse
+     */
+   public function put(IRequest $request, IResponse $response, array $routeArguments);
+}

--- a/Tools/Libraries/ARepository.php
+++ b/Tools/Libraries/ARepository.php
@@ -98,7 +98,46 @@ abstract class ARepository
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    abstract public function postOne(array $data, AEntite $entite);
+    public function postOne(array $data, AEntite $entite)
+    {
+        if (!$this->hasAllRequired($data)) {
+            throw new MissingArgumentException('');
+        }
+
+        try {
+            $entite->populate($data);
+            $dataDao = $this->getEntite2DataDao($entite);
+
+            return $this->dao->post($dataDao);
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * Vérifie que les données passées possèdent bien tous les champs requis
+     *
+     * @param array $data
+     *
+     * @return bool
+     */
+    protected function hasAllRequired(array $data)
+    {
+        foreach ($this->getListRequired() as $value) {
+            if (!isset($data[$value])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Retourne la liste des champs requis
+     *
+     * @return array
+     */
+    abstract protected function getListRequired();
 
     /*************************************************
      * PUT
@@ -113,7 +152,21 @@ abstract class ARepository
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    abstract public function putOne(array $data, AEntite $entite);
+    public function putOne(array $data, AEntite $entite)
+    {
+        if (!$this->hasAllRequired($data)) {
+            throw new MissingArgumentException('');
+        }
+
+        try {
+            $entite->populate($data);
+            $dataDao = $this->getEntite2DataDao($entite);
+
+            return $this->dao->put($dataDao, $entite->getId());
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
 
     /*************************************************
      * DELETE

--- a/Tools/Middlewares.php
+++ b/Tools/Middlewares.php
@@ -74,16 +74,16 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
 $app->add(function (IRequest $request, IResponse $response, callable $next) {
     try {
         $configuration = json_decode(file_get_contents(ROOT_PATH . 'configuration.json'));
-        $config = new DBAL\Configuration();
-        $connexion = DBAL\DriverManager::getConnection(
-            [
-                'driver' => 'pdo_mysql',
-                'host' => $configuration->db->serveur,
-                'dbname' => $configuration->db->base,
-                'user' => $configuration->db->utilisateur,
-                'password' => $configuration->db->mot_de_passe,
-            ],
-            $config);
+        $dbh = new \PDO(
+            'mysql:host=' . $configuration->db->serveur . ';dbname=' . $configuration->db->base,
+            $configuration->db->utilisateur,
+            $configuration->db->mot_de_passe,
+            [\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES \'utf8\';']
+        );
+        $connexion = DBAL\DriverManager::getConnection([
+                'pdo' => $dbh
+            ]
+        );
         $this['storageConnector'] = $connexion;
 
         return $next($request, $response);

--- a/Tools/Route/Absence.php
+++ b/Tools/Route/Absence.php
@@ -6,18 +6,17 @@
  */
 
 /* Routes sur une absence et associés */
-$app->group('/absences', function () {
+$app->group('/absence', function () {
     /* Route sur un type d'absence */
-    $this->group('/types', function () {
-        $typeNS = '\LibertAPI\Absence\Type\TypeController';
+    $this->group('/type', function () {
         /* Détail */
-        $this->group('/{typeId:[0-9]+}', function () use ($typeNS) {
-            $this->get('', $typeNS . ':get')->setName('getAbsenceTypeDetail');
-            $this->put('', $typeNS . ':put')->setName('putAbsenceTypeDetail');
-            $this->delete('', $typeNS . ':delete')->setName('deleteAbsenceTypeDetail');
+        $this->group('/{typeId:[0-9]+}', function () {
+            $this->get('', 'controller:get')->setName('getAbsenceTypeDetail');
+            $this->put('', 'controller:put')->setName('putAbsenceTypeDetail');
+            $this->delete('', 'controller:delete')->setName('deleteAbsenceTypeDetail');
         });
         /* Collection */
-        $this->get('', $typeNS . ':get')->setName('getAbsenceTypeListe');
-        $this->post('', $typeNS . ':post')->setName('postAbsenceTypeListe');
+        $this->get('', 'controller:get')->setName('getAbsenceTypeListe');
+        $this->post('', 'controller:post')->setName('postAbsenceTypeListe');
     });
 });

--- a/Tools/Route/Absence.php
+++ b/Tools/Route/Absence.php
@@ -9,9 +9,10 @@
 $app->group('/absences', function () {
     /* Route sur un type d'absence */
     $this->group('/types', function () {
-        $type = '\LibertAPI\Absence\Type\TypeController';
-
+        /* Détail */
+        $typeNS = '\LibertAPI\Absence\Type\TypeController';
+        $this->get('/{typeId:[0-9]+}', $typeNS . ':get')->setName('getAbsenceTypeDetail');
         /* Collection */
-        $this->get('', $type . ':get')->setName('getAbsenceTypeListe');
+        $this->get('', $typeNS . ':get')->setName('getAbsenceTypeListe');
     });
 });

--- a/Tools/Route/Absence.php
+++ b/Tools/Route/Absence.php
@@ -6,3 +6,12 @@
  */
 
 /* Routes sur une absence et associés */
+$app->group('/absences', function () {
+    /* Route sur un type d'absence */
+    $this->group('/types', function () {
+        $type = '\LibertAPI\Absence\Type\TypeController';
+
+        /* Collection */
+        $this->get('', $type . ':get')->setName('getAbsenceTypeListe');
+    });
+});

--- a/Tools/Route/Absence.php
+++ b/Tools/Route/Absence.php
@@ -1,0 +1,8 @@
+<?php
+/*
+ * Doit être importé après la création de $app. Ne créé rien.
+ *
+ * La convention de nommage est de mettre les routes au pluriel
+ */
+
+/* Routes sur une absence et associés */

--- a/Tools/Route/Absence.php
+++ b/Tools/Route/Absence.php
@@ -9,10 +9,15 @@
 $app->group('/absences', function () {
     /* Route sur un type d'absence */
     $this->group('/types', function () {
-        /* Détail */
         $typeNS = '\LibertAPI\Absence\Type\TypeController';
-        $this->get('/{typeId:[0-9]+}', $typeNS . ':get')->setName('getAbsenceTypeDetail');
+        /* Détail */
+        $this->group('/{typeId:[0-9]+}', function () use ($typeNS) {
+            $this->get('', $typeNS . ':get')->setName('getAbsenceTypeDetail');
+            $this->put('', $typeNS . ':put')->setName('putAbsenceTypeDetail');
+            $this->delete('', $typeNS . ':delete')->setName('deleteAbsenceTypeDetail');
+        });
         /* Collection */
         $this->get('', $typeNS . ':get')->setName('getAbsenceTypeListe');
+        $this->post('', $typeNS . ':post')->setName('postAbsenceTypeListe');
     });
 });

--- a/Utilisateur/UtilisateurDao.php
+++ b/Utilisateur/UtilisateurDao.php
@@ -13,6 +13,7 @@ class UtilisateurDao extends \LibertAPI\Tools\Libraries\ADao
 {
     public function getById($id)
     {
+        throw new \RuntimeException('Action is forbidden');
     }
 
     /**

--- a/Utilisateur/UtilisateurRepository.php
+++ b/Utilisateur/UtilisateurRepository.php
@@ -130,6 +130,14 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
     {
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    protected function getListRequired()
+    {
+        return [];
+    }
+
     /*************************************************
      * PUT
      *************************************************/

--- a/Vendor/composer/autoload_psr4.php
+++ b/Vendor/composer/autoload_psr4.php
@@ -15,5 +15,4 @@ return array(
     'Doctrine\\Common\\Inflector\\' => array($vendorDir . '/doctrine/inflector/lib/Doctrine/Common/Inflector'),
     'Doctrine\\Common\\Cache\\' => array($vendorDir . '/doctrine/cache/lib/Doctrine/Common/Cache'),
     'Doctrine\\Common\\Annotations\\' => array($vendorDir . '/doctrine/annotations/lib/Doctrine/Common/Annotations'),
-    '' => array($baseDir . '/'),
 );

--- a/Vendor/composer/installed.json
+++ b/Vendor/composer/installed.json
@@ -458,7 +458,7 @@
         "require": {
             "php": ">=5.3.2"
         },
-        "time": "2014-09-09 13:34:57",
+        "time": "2014-09-09T13:34:57+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
@@ -517,7 +517,7 @@
         "require-dev": {
             "phpunit/phpunit": "^6.2"
         },
-        "time": "2017-07-22 12:18:28",
+        "time": "2017-07-22T12:18:28+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
@@ -587,7 +587,7 @@
             "doctrine/coding-standard": "~0.1@dev",
             "phpunit/phpunit": "^5.7"
         },
-        "time": "2017-07-22 10:37:32",
+        "time": "2017-07-22T10:37:32+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
@@ -664,7 +664,7 @@
         "suggest": {
             "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
         },
-        "time": "2017-08-25 07:02:50",
+        "time": "2017-08-25T07:02:50+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
@@ -733,7 +733,7 @@
             "doctrine/cache": "1.*",
             "phpunit/phpunit": "^5.7"
         },
-        "time": "2017-07-22 10:58:02",
+        "time": "2017-07-22T10:58:02+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
@@ -806,7 +806,7 @@
         "require-dev": {
             "phpunit/phpunit": "~3.7"
         },
-        "time": "2015-12-25 13:10:16",
+        "time": "2015-12-25T13:10:16+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {
@@ -881,7 +881,7 @@
         "suggest": {
             "symfony/console": "For helpful console commands such as SQL execution and import of files."
         },
-        "time": "2014-12-04 21:57:15",
+        "time": "2014-12-04T21:57:15+00:00",
         "bin": [
             "bin/doctrine-dbal"
         ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,6 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a090bc7d5b73829c854abbd33bddb4ed",
     "content-hash": "b67fb88020e17ddbd6be17aebc3c0d9f",
     "packages": [
         {
@@ -36,7 +35,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14 19:40:03"
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -104,7 +103,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-07-22 10:58:02"
+            "time": "2017-07-22T10:58:02+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -178,7 +177,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2017-08-25 07:02:50"
+            "time": "2017-08-25T07:02:50+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -245,7 +244,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2017-07-22 10:37:32"
+            "time": "2017-07-22T10:37:32+00:00"
         },
         {
             "name": "doctrine/common",
@@ -318,7 +317,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-12-25 13:10:16"
+            "time": "2015-12-25T13:10:16+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -389,7 +388,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2014-12-04 21:57:15"
+            "time": "2014-12-04T21:57:15+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -456,7 +455,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2017-07-22 12:18:28"
+            "time": "2017-07-22T12:18:28+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -510,7 +509,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -553,7 +552,7 @@
                 "router",
                 "routing"
             ],
-            "time": "2017-01-19 11:35:12"
+            "time": "2017-01-19T11:35:12+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -599,7 +598,7 @@
                 "container",
                 "dependency injection"
             ],
-            "time": "2015-09-11 15:10:35"
+            "time": "2015-09-11T15:10:35+00:00"
         },
         {
             "name": "psr/container",
@@ -648,7 +647,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14 16:28:37"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",
@@ -698,7 +697,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "raveren/kint",
@@ -750,7 +749,7 @@
                 "php"
             ],
             "abandoned": "kint-php/kint",
-            "time": "2015-09-16 14:09:00"
+            "time": "2015-09-16T14:09:00+00:00"
         },
         {
             "name": "slim/slim",
@@ -820,7 +819,7 @@
                 "micro",
                 "router"
             ],
-            "time": "2016-12-20 20:30:47"
+            "time": "2016-12-20T20:30:47+00:00"
         }
     ],
     "packages-dev": [
@@ -906,7 +905,7 @@
                 "test",
                 "unit testing"
             ],
-            "time": "2017-02-22 13:05:37"
+            "time": "2017-02-22T13:05:37+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Comme le titre l'indique, j'ai ajouté la route `absences/types`. J'aurais pu le mettre sous une route de premier niveau `type_absence` mais ça ne montre pas suffisamment à mon goût la relation d'appartenance. Puisque j'ai ajouté une route, il commence à y avoir plein de factorisation à faire, j'ai donc fait ce qui était nécessaire / utile à ce stade. J'ai aussi posé des interfaces, ça aide à mieux se représenter les responsabilités associées au contrôleur.