### PR TITLE
Easy Peasy routers

### DIFF
--- a/Tests/Units/Tools/Libraries/AControllerFactory.php
+++ b/Tests/Units/Tools/Libraries/AControllerFactory.php
@@ -79,16 +79,4 @@ final class AControllerFactory extends \Atoum
 
         $this->object($controller)->isInstanceOf(_AController::class);
     }
-
-    /**
-     * Test de la résolution de namespace pour le contrôleur
-     */
-    public function testGetControllerClassname()
-    {
-        $ressource = 'Planning\Creneau';
-        $class = $this->testedClass()->getClass();
-        $this->string($class::getControllerClassname($ressource))
-            ->isIdenticalTo('\LibertAPI\Planning\Creneau\CreneauController')
-        ;
-    }
 }

--- a/Tools/Libraries/AControllerFactory.php
+++ b/Tools/Libraries/AControllerFactory.php
@@ -87,7 +87,7 @@ abstract class AControllerFactory
      *
      * @return string
      */
-    final public static function getControllerClassname($ressourcePath)
+    final private static function getControllerClassname($ressourcePath)
     {
         $paths = explode('\\', $ressourcePath);
         $end = array_pop($paths);

--- a/Tools/Middlewares.php
+++ b/Tools/Middlewares.php
@@ -31,7 +31,7 @@ $app->add(function (IRequest $request, IResponse $response, callable $next) {
                     $this['currentUser']
                 );
             }
-            $this[AControllerFactory::getControllerClassname($ressourcePath)] = $controller;
+            $this['controller'] = $controller;
         } catch (\DomainException $e) {
             return call_user_func(
                 $this->notFoundHandler,

--- a/Tools/Route/Authentification.php
+++ b/Tools/Route/Authentification.php
@@ -2,4 +2,4 @@
 /*
  * Doit être importé après la création de $app. Ne créé rien.
  */
-$app->get('/authentification', '\LibertAPI\Authentification\AuthentificationController:get')->setName('authentification');
+$app->get('/authentification', 'controller:get')->setName('authentification');

--- a/Tools/Route/Plannings.php
+++ b/Tools/Route/Plannings.php
@@ -7,28 +7,26 @@
 
 /* Routes sur le planning et associés */
 $app->group('/plannings', function () {
-    $planningNS = '\LibertAPI\Planning\PlanningController';
-    $this->group('/{planningId:[0-9]+}', function () use ($planningNS) {
+    $this->group('/{planningId:[0-9]+}', function () {
         /* Detail */
-        $this->get('', $planningNS . ':get')->setName('getPlanningDetail');
-        $this->put('', $planningNS . ':put')->setName('putPlanningDetail');
-        $this->delete('', $planningNS . ':delete')->setName('deletePlanningDetail');
+        $this->get('', 'controller:get')->setName('getPlanningDetail');
+        $this->put('', 'controller:put')->setName('putPlanningDetail');
+        $this->delete('', 'controller:delete')->setName('deletePlanningDetail');
 
         /* Dependances de plannings */
         $this->group('/creneaux', function () {
-            $creneauNS = '\LibertAPI\Planning\Creneau\CreneauController';
             /* Detail creneaux */
-            $this->get('/{creneauId:[0-9]+}', $creneauNS . ':get')->setName('getPlanningCreneauDetail');
-            $this->put('/{creneauId:[0-9]+}', $creneauNS . ':put')->setName('putPlanningCreneauDetail');
+            $this->get('/{creneauId:[0-9]+}', 'controller:get')->setName('getPlanningCreneauDetail');
+            $this->put('/{creneauId:[0-9]+}', 'controller:put')->setName('putPlanningCreneauDetail');
             //$this->delete('/{creneauId:[0-9]+}', $creneauNS . ':delete')->setName('deletePlanningCreneauDetail');
 
             /* Collection creneaux */
-            $this->get('', $creneauNS . ':get')->setName('getPlanningCreneauListe');
-            $this->post('', $creneauNS . ':post')->setName('postPlanningCreneauListe');
+            $this->get('', 'controller:get')->setName('getPlanningCreneauListe');
+            $this->post('', 'controller:post')->setName('postPlanningCreneauListe');
         });
     });
 
     /* Collection */
-    $this->get('', $planningNS .  ':get')->setName('getPlanningListe');
-    $this->post('', $planningNS .  ':post')->setName('postPlanningListe');
+    $this->get('', 'controller:get')->setName('getPlanningListe');
+    $this->post('', 'controller:post')->setName('postPlanningListe');
 });

--- a/Tools/Route/Utilisateurs.php
+++ b/Tools/Route/Utilisateurs.php
@@ -7,12 +7,11 @@
 
 /* Routes sur l'utilisateur et associés */
 $app->group('/utilisateurs', function () {
-    $utilisateurNS = '\App\Components\Utilisateur\Controller';
-    $this->group('/{utilisateurId:[0-9]+}', function () use ($utilisateurNS) {
+    $this->group('/{utilisateurId:[0-9]+}', function () {
         /* Detail */
-        $this->get('', $utilisateurNS . ':get')->setName('getUtilisateurDetail');
+        $this->get('', 'controller:get')->setName('getUtilisateurDetail');
     });
 
     /* Collection */
-    $this->get('', $utilisateurNS .  ':get')->setName('getUtilisateurListe');
+    $this->get('', 'controller:get')->setName('getUtilisateurListe');
 });

--- a/Utilisateur/UtilisateurController.php
+++ b/Utilisateur/UtilisateurController.php
@@ -16,12 +16,12 @@ use Psr\Http\Message\ResponseInterface as IResponse;
  * Ne devrait être contacté que par le routeur
  * Ne devrait contacter que le Utilisateur\Repository
  */
-final class UtilisateurController extends \App\Libraries\AController
+final class UtilisateurController extends \LibertAPI\Tools\Libraries\AController
 {
     /**
      * {@inheritDoc}
      */
-    protected function ensureAccessUser($order, LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
     }
 


### PR DESCRIPTION
Les fichiers de route s'appuyaient sur un namespace pour le matching avec le contrôleur créé préalablement. C'est source de confusion. Comme il n'y aura toujours qu'un contrôleur de lancé à un instant T, je supprime ce nom et simplifie.