### PR TITLE
Un DAO doit retourner un objet métier

### DIFF
--- a/Absence/Type/TypeDao.php
+++ b/Absence/Type/TypeDao.php
@@ -26,7 +26,7 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
         $this->setWhere(['id' => $id]);
         $res = $this->queryBuilder->execute();
 
-        $data = $res->fetch(\PDO::FETCH_ASSOC);;
+        $data = $res->fetch(\PDO::FETCH_ASSOC);
         if (empty($data)) {
             throw new \DomainException('#' . $id . ' is not a valid resource');
         }

--- a/Absence/Type/TypeDao.php
+++ b/Absence/Type/TypeDao.php
@@ -1,6 +1,8 @@
 <?php
 namespace LibertAPI\Absence\Type;
 
+use LibertAPI\Tools\Libraries\AEntite;
+
 /**
  * {@inheritDoc}
  *
@@ -24,7 +26,25 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
         $this->setWhere(['id' => $id]);
         $res = $this->queryBuilder->execute();
 
-        return $res->fetch(\PDO::FETCH_ASSOC);
+        $data = $res->fetch(\PDO::FETCH_ASSOC);;
+        if (empty($data)) {
+            throw new \DomainException('#' . $id . ' is not a valid resource');
+        }
+
+        return new TypeEntite($this->getStorage2Entite($data));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getStorage2Entite(array $dataDao)
+    {
+        return [
+            'id' => $dataDao['ta_id'],
+            'type' => $dataDao['ta_type'],
+            'libelle' => $dataDao['ta_libelle'],
+            'libelleCourt' => $dataDao['ta_short_libelle'],
+        ];
     }
 
     /**
@@ -40,7 +60,18 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
         }
         $res = $this->queryBuilder->execute();
 
-        return $res->fetchAll(\PDO::FETCH_ASSOC);
+        $data = $res->fetchAll(\PDO::FETCH_ASSOC);
+        if (empty($data)) {
+            throw new \UnexpectedValueException('No resource match with these parameters');
+        }
+
+        $entites = [];
+        foreach ($data as $value) {
+            $entite = new TypeEntite($this->getStorage2Entite($value));
+            $entites[$entite->getId()] = $entite;
+        }
+
+        return $entites;
     }
 
     /*************************************************
@@ -50,10 +81,10 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function post(array $data)
+    public function post(AEntite $entite)
     {
         $this->queryBuilder->insert($this->getTableName());
-        $this->setValues($data);
+        $this->setValues($this->getEntite2Storage($entite));
         $this->queryBuilder->execute();
 
         return $this->storageConnector->lastInsertId();
@@ -81,14 +112,26 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function put(array $data, $id)
+    public function put(AEntite $entite)
     {
         $this->queryBuilder->update($this->getTableName());
-        $this->setSet($data);
+        $this->setSet($this->getEntite2Storage($entite));
         $this->queryBuilder->where('ta_id = :id');
-        $this->queryBuilder->setParameter(':id', $id);
+        $this->queryBuilder->setParameter(':id', $entite->getId());
 
         $this->queryBuilder->execute();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getEntite2Storage(AEntite $entite)
+    {
+        return [
+            'type' => $entite->getType(),
+            'libelle' => $entite->getLibelle(),
+            'libelleCourt' => $entite->getLibelleCourt(),
+        ];
     }
 
     private function setSet(array $parametres)

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -19,52 +19,6 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
      *************************************************/
 
     /**
-     * @inheritDoc
-     */
-    public function getOne($id)
-    {
-        $id = (int) $id;
-        $data = $this->dao->getById($id);
-        if (empty($data)) {
-            throw new \DomainException('Type#' . $id . ' is not a valid resource');
-        }
-
-        return new TypeEntite($this->getDataDao2Entite($data));
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getList(array $parametres)
-    {
-        $data = $this->dao->getList($this->getParamsConsumer2Dao($parametres));
-        if (empty($data)) {
-            throw new \UnexpectedValueException('No resource match with these parameters');
-        }
-
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new TypeEntite($this->getDataDao2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
-
-        return $entites;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getDataDao2Entite(array $dataDao)
-    {
-        return [
-            'id' => $dataDao['ta_id'],
-            'type' => $dataDao['ta_type'],
-            'libelle' => $dataDao['ta_libelle'],
-            'libelleCourt' => $dataDao['ta_short_libelle'],
-        ];
-    }
-
-    /**
      * {@inheritDoc}
      */
     final protected function getParamsConsumer2Dao(array $paramsConsumer)
@@ -88,26 +42,6 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
             $results['gt'] = $filterInt($paramsConsumer['start-before']);
         }
         return $results;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getEntite2DataDao(AEntite $entite)
-    {
-        return [
-            'type' => $entite->getType(),
-            'libelle' => $entite->getLibelle(),
-            'libelleCourt' => $entite->getLibelleCourt(),
-        ];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function getListRequired()
-    {
-        return ['type', 'libelle', 'libelleCourt'];
     }
 
     /**

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -14,10 +14,6 @@ use LibertAPI\Tools\Libraries\AEntite;
  */
 class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
 {
-    /*************************************************
-     * GET
-     *************************************************/
-
     /**
      * {@inheritDoc}
      */

--- a/Journal/JournalDao.php
+++ b/Journal/JournalDao.php
@@ -1,6 +1,8 @@
 <?php
 namespace LibertAPI\Journal;
 
+use LibertAPI\Tools\Libraries\AEntite;
+
 /**
  * {@inheritDoc}
  *
@@ -36,7 +38,34 @@ class JournalDao extends \LibertAPI\Tools\Libraries\ADao
         }
         $res = $this->queryBuilder->execute();
 
-        return $res->fetchAll(\PDO::FETCH_ASSOC);
+        $data = $res->fetchAll(\PDO::FETCH_ASSOC);
+        if (empty($data)) {
+            throw new \UnexpectedValueException('No resource match with these parameters');
+        }
+
+        $entites = [];
+        foreach ($data as $value) {
+            $entite = new JournalEntite($this->getStorage2Entite($value));
+            $entites[$entite->getId()] = $entite;
+        }
+
+        return $entites;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getStorage2Entite(array $dataDao)
+    {
+        return [
+            'id' => $dataDao['log_id'],
+            'numeroPeriode' => $dataDao['log_p_num'],
+            'utilisateurActeur' => $dataDao['log_user_login_par'],
+            'utilisateurObjet' => $dataDao['log_user_login_pour'],
+            'etat' => $dataDao['log_etat'],
+            'commentaire' => $dataDao['log_comment'],
+            'date' => $dataDao['log_date'],
+        ];
     }
 
     /*************************************************
@@ -46,7 +75,7 @@ class JournalDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function post(array $data)
+    public function post(AEntite $entite)
     {
         throw new \RuntimeException('Action is forbidden');
     }
@@ -58,7 +87,15 @@ class JournalDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function put(array $data, $id)
+    public function put(AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getEntite2Storage(AEntite $entite)
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Journal/JournalRepository.php
+++ b/Journal/JournalRepository.php
@@ -29,48 +29,6 @@ class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function getList(array $parametres)
-    {
-        /* TODO: retourner une collection pour avoir le total, hors limite forcée (utile pour la pagination) */
-        /*
-        several params :
-        offset (first, !isset => 0) / start-after ?
-        Limit (nb elements)
-        filter (dimensions forced)
-        */
-        $data = $this->dao->getList($this->getParamsConsumer2Dao($parametres));
-        if (empty($data)) {
-            throw new \UnexpectedValueException('No resource match with these parameters');
-        }
-
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new JournalEntite($this->getDataDao2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
-
-        return $entites;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getDataDao2Entite(array $dataDao)
-    {
-        return [
-            'id' => $dataDao['log_id'],
-            'numeroPeriode' => $dataDao['log_p_num'],
-            'utilisateurActeur' => $dataDao['log_user_login_par'],
-            'utilisateurObjet' => $dataDao['log_user_login_pour'],
-            'etat' => $dataDao['log_etat'],
-            'commentaire' => $dataDao['log_comment'],
-            'date' => $dataDao['log_date'],
-        ];
-    }
-
-    /**
-     * @inheritDoc
-     */
     final protected function getParamsConsumer2Dao(array $paramsConsumer)
     {
         $filterInt = function ($var) {
@@ -86,7 +44,6 @@ class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
         }
         if (!empty($paramsConsumer['start-after'])) {
             $results['lt'] = $filterInt($paramsConsumer['start-after']);
-
         }
         if (!empty($paramsConsumer['start-before'])) {
             $results['gt'] = $filterInt($paramsConsumer['start-before']);
@@ -102,19 +59,6 @@ class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
      * @inheritDoc
      */
     public function postOne(array $data, AEntite $entite)
-    {
-        throw new \RuntimeException('Action is forbidden');
-    }
-
-    protected function getListRequired()
-    {
-        return [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getEntite2DataDao(AEntite $entite)
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Planning/Creneau/CreneauEntite.php
+++ b/Planning/Creneau/CreneauEntite.php
@@ -1,6 +1,8 @@
 <?php
 namespace LibertAPI\Planning\Creneau;
 
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+
 /**
  * {@inheritDoc}
  *
@@ -80,6 +82,9 @@ class CreneauEntite extends \LibertAPI\Tools\Libraries\AEntite
      */
     public function populate(array $data)
     {
+        if (!$this->hasAllRequired($data)) {
+            throw new MissingArgumentException('');
+        }
         $this->setPlanningId($data['planningId']);
         $this->setJourId($data['jourId']);
         $this->setTypeSemaine($data['typeSemaine']);
@@ -91,6 +96,34 @@ class CreneauEntite extends \LibertAPI\Tools\Libraries\AEntite
         if (!empty($erreurs)) {
             throw new \DomainException(json_encode($erreurs));
         }
+    }
+
+    /**
+     * Vérifie que les données passées possèdent bien tous les champs requis
+     *
+     * @param array $data
+     *
+     * @return bool
+     */
+    private function hasAllRequired(array $data)
+    {
+        foreach ($this->getListRequired() as $value) {
+            if (!isset($data[$value])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Retourne la liste des champs requis
+     *
+     * @return array
+     */
+    private function getListRequired()
+    {
+        return ['planningId', 'jourId', 'typeSemaine', 'typePeriode', 'debut', 'fin'];
     }
 
     private function setPlanningId($planningId)

--- a/Planning/Creneau/CreneauRepository.php
+++ b/Planning/Creneau/CreneauRepository.php
@@ -26,49 +26,7 @@ class CreneauRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     public function getOne($id, $planningId = -1)
     {
-        $id = (int) $id;
-        $data = $this->dao->getById($id, $planningId);
-        if (empty($data)) {
-            throw new \DomainException('Creneau#' . $id . ' is not a valid resource');
-        }
-
-        return new CreneauEntite($this->getDataDao2Entite($data));
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getList(array $parametres)
-    {
-        /* retourner une collection pour avoir le total, hors limite forcée (utile pour la pagination) */
-        $data = $this->dao->getList($this->getParamsConsumer2Dao($parametres));
-        if (empty($data)) {
-            throw new \UnexpectedValueException('No resource match with these parameters');
-        }
-
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new CreneauEntite($this->getDataDao2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
-
-        return $entites;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getDataDao2Entite(array $dataDao)
-    {
-        return [
-            'id' => $dataDao['creneau_id'],
-            'planningId' => $dataDao['planning_id'],
-            'jourId' => $dataDao['jour_id'],
-            'typeSemaine' => $dataDao['type_semaine'],
-            'typePeriode' => $dataDao['type_periode'],
-            'debut' => $dataDao['debut'],
-            'fin' => $dataDao['fin'],
-        ];
+        return $this->dao->getById((int) $id, $planningId);
     }
 
     /**
@@ -125,29 +83,6 @@ class CreneauRepository extends \LibertAPI\Tools\Libraries\ARepository
         $this->dao->commit();
 
         return $postIds;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getEntite2DataDao(AEntite $entite)
-    {
-        return [
-            'planning_id' => $entite->getPlanningId(),
-            'jour_id' => $entite->getJourId(),
-            'type_semaine' => $entite->getTypeSemaine(),
-            'type_periode' => $entite->getTypePeriode(),
-            'debut' => $entite->getDebut(),
-            'fin' => $entite->getFin(),
-        ];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function getListRequired()
-    {
-        return ['planningId', 'jourId', 'typeSemaine', 'typePeriode', 'debut', 'fin'];
     }
 
     /*************************************************

--- a/Planning/PlanningDao.php
+++ b/Planning/PlanningDao.php
@@ -1,6 +1,8 @@
 <?php
 namespace LibertAPI\Planning;
 
+use LibertAPI\Tools\Libraries\AEntite;
+
 /**
  * {@inheritDoc}
  *
@@ -27,7 +29,24 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
         $this->setWhere(['id' => $id]);
         $res = $this->queryBuilder->execute();
 
-        return $res->fetch(\PDO::FETCH_ASSOC);
+        $data = $res->fetch(\PDO::FETCH_ASSOC);;
+        if (empty($data)) {
+            throw new \DomainException('#' . $id . ' is not a valid resource');
+        }
+
+        return new PlanningEntite($this->getStorage2Entite($data));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getStorage2Entite(array $dataDao)
+    {
+        return [
+            'id' => $dataDao['planning_id'],
+            'name' => $dataDao['name'],
+            'status' => $dataDao['status'],
+        ];
     }
 
     /**
@@ -43,7 +62,18 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
         }
         $res = $this->queryBuilder->execute();
 
-        return $res->fetchAll(\PDO::FETCH_ASSOC);
+        $data = $res->fetchAll(\PDO::FETCH_ASSOC);
+        if (empty($data)) {
+            throw new \UnexpectedValueException('No resource match with these parameters');
+        }
+
+        $entites = [];
+        foreach ($data as $value) {
+            $entite = new PlanningEntite($this->getStorage2Entite($value));
+            $entites[$entite->getId()] = $entite;
+        }
+
+        return $entites;
     }
 
     /*************************************************
@@ -53,10 +83,10 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function post(array $data)
+    public function post(AEntite $entite)
     {
         $this->queryBuilder->insert($this->getTableName());
-        $this->setValues($data);
+        $this->setValues($this->getEntite2Storage($entite));
         $this->queryBuilder->execute();
 
         return $this->storageConnector->lastInsertId();
@@ -81,14 +111,25 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     /**
      * @inheritDoc
      */
-    public function put(array $data, $id)
+    public function put(AEntite $entite)
     {
         $this->queryBuilder->update($this->getTableName());
+        $this->setSet($this->getEntite2Storage($entite));
         $this->queryBuilder->where('planning_id = :id');
-        $this->queryBuilder->setParameter(':id', $id);
-        $this->setSet($data);
+        $this->queryBuilder->setParameter(':id', $entite->getId());
 
         $this->queryBuilder->execute();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getEntite2Storage(AEntite $entite)
+    {
+        return [
+            'name' => $entite->getName(),
+            'status' => $entite->getStatus(),
+        ];
     }
 
     private function setSet(array $parametres)

--- a/Planning/PlanningDao.php
+++ b/Planning/PlanningDao.php
@@ -29,7 +29,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
         $this->setWhere(['id' => $id]);
         $res = $this->queryBuilder->execute();
 
-        $data = $res->fetch(\PDO::FETCH_ASSOC);;
+        $data = $res->fetch(\PDO::FETCH_ASSOC);
         if (empty($data)) {
             throw new \DomainException('#' . $id . ' is not a valid resource');
         }

--- a/Planning/PlanningEntite.php
+++ b/Planning/PlanningEntite.php
@@ -1,6 +1,8 @@
 <?php
 namespace LibertAPI\Planning;
 
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+
 /**
  * @inheritDoc
  *
@@ -40,6 +42,9 @@ class PlanningEntite extends \LibertAPI\Tools\Libraries\AEntite
      */
     public function populate(array $data)
     {
+        if (!$this->hasAllRequired($data)) {
+            throw new MissingArgumentException('');
+        }
         $this->setName($data['name']);
         $this->setStatus($data['status']);
 
@@ -47,6 +52,34 @@ class PlanningEntite extends \LibertAPI\Tools\Libraries\AEntite
         if (!empty($erreurs)) {
             throw new \DomainException(json_encode($erreurs));
         }
+    }
+
+    /**
+     * Vérifie que les données passées possèdent bien tous les champs requis
+     *
+     * @param array $data
+     *
+     * @return bool
+     */
+    private function hasAllRequired(array $data)
+    {
+        foreach ($this->getListRequired() as $value) {
+            if (!isset($data[$value])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Retourne la liste des champs requis
+     *
+     * @return array
+     */
+    private function getListRequired()
+    {
+        return ['name', 'status'];
     }
 
     /**

--- a/Planning/PlanningRepository.php
+++ b/Planning/PlanningRepository.php
@@ -1,7 +1,6 @@
 <?php
 namespace LibertAPI\Planning;
 
-use LibertAPI\Tools\Exceptions\MissingArgumentException;
 use LibertAPI\Tools\Libraries\AEntite;
 
 /**
@@ -21,58 +20,6 @@ class PlanningRepository extends \LibertAPI\Tools\Libraries\ARepository
     /*************************************************
      * GET
      *************************************************/
-
-    /**
-     * @inheritDoc
-     */
-    public function getOne($id)
-    {
-        $id = (int) $id;
-        $data = $this->dao->getById($id);
-        if (empty($data)) {
-            throw new \DomainException('Planning#' . $id . ' is not a valid resource');
-        }
-
-        return new PlanningEntite($this->getDataDao2Entite($data));
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getList(array $parametres)
-    {
-        /* TODO: retourner une collection pour avoir le total, hors limite forcée (utile pour la pagination) */
-        /*
-        several params :
-        offset (first, !isset => 0) / start-after ?
-        Limit (nb elements)
-        filter (dimensions forced)
-        */
-        $data = $this->dao->getList($this->getParamsConsumer2Dao($parametres));
-        if (empty($data)) {
-            throw new \UnexpectedValueException('No resource match with these parameters');
-        }
-
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new PlanningEntite($this->getDataDao2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
-
-        return $entites;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getDataDao2Entite(array $dataDao)
-    {
-        return [
-            'id' => $dataDao['planning_id'],
-            'name' => $dataDao['name'],
-            'status' => $dataDao['status'],
-        ];
-    }
 
     /**
      * @inheritDoc
@@ -100,28 +47,6 @@ class PlanningRepository extends \LibertAPI\Tools\Libraries\ARepository
         return $results;
     }
 
-    /*************************************************
-     * POST
-     *************************************************/
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getEntite2DataDao(AEntite $entite)
-    {
-        return [
-            'name' => $entite->getName(),
-            'status' => $entite->getStatus(),
-        ];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function getListRequired()
-    {
-        return ['name', 'status'];
-    }
 
     /*************************************************
      * DELETE

--- a/Public/index.php
+++ b/Public/index.php
@@ -27,6 +27,6 @@ require_once ROUTE_PATH . 'Absence.php';
 require_once ROUTE_PATH . 'Authentification.php';
 require_once ROUTE_PATH . 'Journal.php';
 require_once ROUTE_PATH . 'Planning.php';
-require_once ROUTE_PATH . 'Utilisateurs.php';
+require_once ROUTE_PATH . 'Utilisateur.php';
 /* Jump in ! */
 $app->run();

--- a/Tests/Units/Absence/Type/TypeDao.php
+++ b/Tests/Units/Absence/Type/TypeDao.php
@@ -1,6 +1,8 @@
 <?php
 namespace LibertAPI\Tests\Units\Absence\Type;
 
+use LibertAPI\Absence\Type\TypeEntite;
+
 /**
  * Classe de test du DAO de type d'absence
  *
@@ -23,11 +25,7 @@ final class TypeDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->calling($this->connector)->lastInsertId = 314;
         $this->newTestedInstance($this->connector);
 
-        $postId = $this->testedInstance->post([
-            'type' => 'type',
-            'libelle' => 'libelle',
-            'libelleCourt' => 'libelleCourt',
-        ]);
+        $postId = $this->testedInstance->post(new TypeEntite($this->entiteContent));
 
         $this->integer($postId)->isIdenticalTo(314);
     }
@@ -43,12 +41,25 @@ final class TypeDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     {
         $this->newTestedInstance($this->connector);
 
-        $put = $this->testedInstance->put([
-            'type' => 'type',
-            'libelle' => 'libelle',
-            'libelleCourt' => 'libelleCourt',
-        ], 12);
+        $put = $this->testedInstance->put(new TypeEntite($this->entiteContent));
 
         $this->variable($put)->isNull();
     }
+
+    protected function getStorageContent()
+    {
+        return [
+            'ta_id' => 38,
+            'ta_type' => 81,
+            'ta_libelle' => 'libelle',
+            'ta_short_libelle' => 'li',
+        ];
+    }
+
+    private $entiteContent = [
+        'id' => 33,
+        'type' => 'top',
+        'libelle' => 'ellebil',
+        'libelleCourt' => 'el',
+    ];
 }

--- a/Tests/Units/Absence/Type/TypeRepository.php
+++ b/Tests/Units/Absence/Type/TypeRepository.php
@@ -9,179 +9,18 @@ namespace LibertAPI\Tests\Units\Absence\Type;
  *
  * @since 0.5
  */
-final class TypeRepository extends \Atoum
+final class TypeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
 {
-    /**
-     * @var \LibertAPI\Absence\Type\TypeDao Mock du DAO du planning
-     */
-    private $dao;
-
-    /**
-     * @var \LibertAPI\Absence\Type\TypeEntite Mock de l'Entité de planning
-     */
-    private $entite;
-
-    public function beforeTestMethod($method)
+    protected function initDao()
     {
-        parent::beforeTestMethod($method);
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\LibertAPI\Absence\Type\TypeDao();
-        $this->mockGenerator->orphanize('__construct');
-        $this->entite = new \LibertAPI\Absence\Type\TypeEntite([
-            'id' => 42,
-            'type' => 'thieft',
-            'libelle' => 'GTA',
-            'libelleCourt' => 'vice'
-        ]);
     }
 
-    /*************************************************
-     * GET
-     *************************************************/
-
-    /**
-     * Teste la méthode getOne avec un id non trouvé
-     */
-    public function testGetOneNotFound()
+    protected function initEntite()
     {
-        $this->dao->getMockController()->getById = [];
-        $this->newTestedInstance($this->dao);
-        $this->exception(function () {
-            $this->testedInstance->getOne(99);
-        })->isInstanceOf('\DomainException');
-    }
-
-    /**
-     * Teste la méthode getOne avec un id trouvé
-     */
-    public function testGetOneFound()
-    {
-        $this->dao->getMockController()->getById = [
-            'ta_id' => 42,
-            'ta_type' => 'aventure',
-            'ta_libelle' => 'AS',
-            'ta_short_libelle' => 'creed',
-        ];
-        $this->newTestedInstance($this->dao);
-        $entite = $this->testedInstance->getOne(42);
-
-        $this->object($entite)->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
-        $this->integer($entite->getId())->isIdenticalTo(42);
-    }
-
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->dao->getMockController()->getList = [];
-        $this->newTestedInstance($this->dao);
-
-        $this->exception(function () {
-            $this->testedInstance->getList([]);
-        })->isInstanceOf('\UnexpectedValueException');
-    }
-
-    /**
-     * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->dao->getMockController()->getList = [[
-            'ta_id' => 42,
-            'ta_type' => 'aventure',
-            'ta_libelle' => 'AS',
-            'ta_short_libelle' => 'creed',
-        ]];
-        $this->newTestedInstance($this->dao);
-        $entites = $this->testedInstance->getList([]);
-
-        $this->array($entites)->hasKey(42);
-        $this->object($entites[42])->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
-    }
-
-    /*************************************************
-     * POST
-     *************************************************/
-
-    /**
-     * Teste la méthode postOne avec un champ manquant
-     */
-    public function testPostOneMissingArg()
-    {
-        $this->newTestedInstance($this->dao);
-
-        $this->exception(function () {
-            $this->testedInstance->postOne(['name' => 'bob'], new \LibertAPI\Absence\Type\TypeEntite([]));
-        })->isInstanceOf('\LibertAPI\Tools\Exceptions\MissingArgumentException');
-    }
-
-    /**
-     * Teste la méthode postOne avec un champ incohérent
-     */
-    public function testPostOneBadDomain()
-    {
-        $this->newTestedInstance($this->dao);
-        $entite = new \LibertAPI\Absence\Type\TypeEntite([]);
-
-        $this->exception(function () use ($entite) {
-            $this->testedInstance->postOne(['type' => '', 'libelle' => 'Roger', 'libelleCourt' => 'Maverick'], $entite);
-        })->isInstanceOf('\DomainException');
-    }
-
-    /**
-     * Teste la méthode postOne quand tout est ok
-     */
-    public function testPostOneOk()
-    {
-        $this->dao->getMockController()->post = 3;
-        $this->newTestedInstance($this->dao);
-
-        $post = $this->testedInstance->postOne(['type' => 'Holly', 'libelle' => 'Roger', 'libelleCourt' => 'Maverick'], $this->entite);
-
-        $this->integer($post);
-    }
-
-    /*************************************************
-     * PUT
-     *************************************************/
-
-    /**
-     * Teste la méthode putOne avec un champ manquant
-     */
-    public function testPutOneMissingArgument()
-    {
-        $this->newTestedInstance($this->dao);
-
-        $this->exception(function () {
-            $this->testedInstance->putOne(['libelle' => 'Roger', 'libelleCourt' => 'Maverick'], new \LibertAPI\Absence\Type\TypeEntite([]));
-        })->isInstanceOf('\LibertAPI\Tools\Exceptions\MissingArgumentException');
-    }
-
-    /**
-     * Teste la méthode putOne avec un champ incohérent
-     */
-    public function testPutOneBadDomain()
-    {
-        $this->newTestedInstance($this->dao);
-        $entite = new \LibertAPI\Absence\Type\TypeEntite([]);
-
-        $this->exception(function () use ($entite) {
-            $this->testedInstance->putOne(['type' => '', 'libelle' => 'Roger', 'libelleCourt' => 'Maverick'], $entite);
-        })->isInstanceOf('\DomainException');
-    }
-
-    /**
-     * Teste la méthode putOne tout ok
-     */
-    public function testPutOneOk()
-    {
-        $this->newTestedInstance($this->dao);
-
-        $result = $this->testedInstance->putOne(['type' => 'Holly', 'libelle' => 'Roger', 'libelleCourt' => 'Maverick'], $this->entite);
-
-        $this->variable($result)->isNull();
+        $this->entite = new \LibertAPI\Absence\Type\TypeEntite([]);
     }
 
     /*************************************************
@@ -214,5 +53,15 @@ final class TypeRepository extends \Atoum
         $entite = new \LibertAPI\Absence\Type\TypeEntite([]);
 
         $this->variable($this->testedInstance->deleteOne($entite))->isNull();
+    }
+
+    protected function getEntiteContent()
+    {
+        return [
+            'id' => 87,
+            'type' => 'quatre',
+            'libelle' => 'chipolata',
+            'libelleCourt' => 'cp',
+        ];
     }
 }

--- a/Tests/Units/Authentification/AuthentificationController.php
+++ b/Tests/Units/Authentification/AuthentificationController.php
@@ -14,7 +14,6 @@ final class AuthentificationController extends \LibertAPI\Tests\Units\Tools\Libr
     protected function initRepository()
     {
         $this->mockGenerator->orphanize('__construct');
-        $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\LibertAPI\Utilisateur\UtilisateurRepository();
     }
 

--- a/Tests/Units/Journal/JournalDao.php
+++ b/Tests/Units/Journal/JournalDao.php
@@ -35,32 +35,6 @@ final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         });
     }
 
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->calling($this->result)->fetchAll = [];
-        $dao = $this->newTestedInstance($this->connector);
-
-        $get = $dao->getList([]);
-
-        $this->array($get)->isEmpty();
-    }
-
-    /**
-     * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->calling($this->result)->fetchAll = [['a']];
-        $dao = $this->newTestedInstance($this->connector);
-
-        $get = $dao->getList([]);
-
-        $this->array($get[0])->isNotEmpty();
-    }
-
     /*************************************************
      * POST
      *************************************************/

--- a/Tests/Units/Journal/JournalDao.php
+++ b/Tests/Units/Journal/JournalDao.php
@@ -108,4 +108,17 @@ final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
             $this->testedInstance->delete([]);
         })->isInstanceOf(\RuntimeException::class);
     }
+
+    protected function getStorageContent()
+    {
+        return [
+            'log_id' => 81,
+            'log_p_num' => 1213,
+            'log_user_login_par' => 'Baloo',
+            'log_user_login_pour' => 'Mowgli',
+            'log_etat' => 'gere',
+            'log_comment' => 'nope',
+            'log_date' => '2017-12-01',
+        ];
+    }
 }

--- a/Tests/Units/Journal/JournalRepository.php
+++ b/Tests/Units/Journal/JournalRepository.php
@@ -22,7 +22,7 @@ final class JournalRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
 
     protected function initEntite()
     {
-        $this->entite = new JournalEntite([]);
+        $this->entite = new \LibertAPI\Journal\JournalEntite([]);
     }
 
     /*************************************************

--- a/Tests/Units/Journal/JournalRepository.php
+++ b/Tests/Units/Journal/JournalRepository.php
@@ -1,8 +1,6 @@
 <?php
 namespace LibertAPI\Tests\Units\Journal;
 
-use LibertAPI\Journal\JournalEntite;
-
 /**
  * Classe de test du repository de journal
  *

--- a/Tests/Units/Journal/JournalRepository.php
+++ b/Tests/Units/Journal/JournalRepository.php
@@ -1,7 +1,7 @@
 <?php
 namespace LibertAPI\Tests\Units\Journal;
 
-use \LibertAPI\Journal\JournalRepository as _Repository;
+use LibertAPI\Journal\JournalEntite;
 
 /**
  * Classe de test du repository de journal
@@ -11,33 +11,18 @@ use \LibertAPI\Journal\JournalRepository as _Repository;
  *
  * @since 0.5
  */
-final class JournalRepository extends \Atoum
+final class JournalRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
 {
-    /**
-     * @var \LibertAPI\Journal\JournalDao Mock du DAO associé
-     */
-    private $dao;
-
-    /**
-     * @var \LibertAPI\Journal\JournalEntite Entité associée
-     */
-    private $entite;
-
-    public function beforeTestMethod($method)
+    protected function initDao()
     {
-        parent::beforeTestMethod($method);
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\LibertAPI\Journal\JournalDao();
-        $this->entite = new \LibertAPI\Journal\JournalEntite([
-            'id' => 42,
-            'numeroPeriode' => 88,
-            'utilisateurActeur' => '4',
-            'utilisateurObjet' => '8',
-            'etat' => 'cassé',
-            'commentaire' => 'c\'est cassé',
-            'date' => 'now',
-        ]);
+    }
+
+    protected function initEntite()
+    {
+        $this->entite = new JournalEntite([]);
     }
 
     /*************************************************
@@ -57,40 +42,6 @@ final class JournalRepository extends \Atoum
         })->isInstanceOf(\RuntimeException::class);
     }
 
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->calling($this->dao)->getList = [];
-        $this->newTestedInstance($this->dao);
-
-        $this->exception(function () {
-            $this->testedInstance->getList([]);
-        })->isInstanceOf(\UnexpectedValueException::class);
-    }
-
-    /**
-     * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->calling($this->dao)->getList = [[
-            'log_id' => '42',
-            'log_p_num' => 73,
-            'log_user_login_par' => 'tintin',
-            'log_user_login_pour' => 'milou',
-            'log_etat' => 'haddock',
-            'log_comment' => 'moulinsart',
-            'log_date' => '43',
-        ]];
-        $this->newTestedInstance($this->dao);
-
-        $entites = $this->testedInstance->getList([]);
-
-        $this->array($entites)->hasKey(42);
-        $this->object($entites[42])->isInstanceOf(\LibertAPI\Tools\Libraries\AEntite::class);
-    }
 
     /*************************************************
      * POST
@@ -138,5 +89,21 @@ final class JournalRepository extends \Atoum
         $this->exception(function () {
             $this->testedInstance->deleteOne($this->entite);
         })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getEntiteContent()
+    {
+        return [
+            'id' => 298,
+            'numeroPeriode' => 1,
+            'utilisateurActeur' => 'Romeo',
+            'utilisateurObjet' => 'Juliette',
+            'etat' => 'gere',
+            'commentaire' => 'nope',
+            'date' => '2017-12-01',
+        ];
     }
 }

--- a/Tests/Units/Planning/Creneau/CreneauController.php
+++ b/Tests/Units/Planning/Creneau/CreneauController.php
@@ -14,7 +14,6 @@ final class CreneauController extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
     protected function initRepository()
     {
         $this->mockGenerator->orphanize('__construct');
-        $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\LibertAPI\Planning\Creneau\CreneauRepository();
     }
 

--- a/Tests/Units/Planning/Creneau/CreneauDao.php
+++ b/Tests/Units/Planning/Creneau/CreneauDao.php
@@ -46,15 +46,35 @@ final class CreneauDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->variable($put)->isNull();
     }
 
-    private $storageContent = [
-        'creneau_id' => 42,
-        'planning_id' => 12,
-        'jour_id' => 7,
-        'type_semaine' => 23,
-        'type_periode' => 2,
-        'debut' => 63,
-        'fin' => 55,
-    ];
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * Teste la méthode delete quand tout est ok
+     */
+    public function testDeleteOk()
+    {
+        $this->calling($this->result)->rowCount = 1;
+        $this->newTestedInstance($this->connector);
+
+        $res = $this->testedInstance->delete(7);
+
+        $this->variable($res)->isNull();
+    }
+
+    protected function getStorageContent()
+    {
+        return [
+            'creneau_id' => 42,
+            'planning_id' => 12,
+            'jour_id' => 7,
+            'type_semaine' => 23,
+            'type_periode' => 2,
+            'debut' => 63,
+            'fin' => 55,
+        ];
+    }
 
     private $entiteContent = [
         'id' => 42,

--- a/Tests/Units/Planning/Creneau/CreneauDao.php
+++ b/Tests/Units/Planning/Creneau/CreneauDao.php
@@ -1,7 +1,7 @@
 <?php
 namespace LibertAPI\Tests\Units\Planning\Creneau;
 
-use \LibertAPI\Planning\Creneau\CreneauDao as _Dao;
+use LibertAPI\Planning\Creneau\CreneauEntite;
 
 /**
  * Classe de test du DAO de créneau de planning
@@ -14,11 +14,6 @@ use \LibertAPI\Planning\Creneau\CreneauDao as _Dao;
 final class CreneauDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
 {
     /*************************************************
-     * GET
-     *************************************************/
-
-
-    /*************************************************
      * POST
      *************************************************/
 
@@ -28,16 +23,9 @@ final class CreneauDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     public function testPostOk()
     {
         $this->connector->getMockController()->lastInsertId = 314;
-        $dao = new _Dao($this->connector);
+        $dao = $this->newTestedInstance($this->connector);
 
-        $postId = $dao->post([
-            'planning_id' => 12,
-            'jour_id' => 7,
-            'type_semaine' => 23,
-            'type_periode' => 2,
-            'debut' => 63,
-            'fin' => 55,
-        ]);
+        $postId = $dao->post(new CreneauEntite($this->entiteContent));
 
         $this->integer($postId)->isIdenticalTo(314);
     }
@@ -51,30 +39,30 @@ final class CreneauDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
      */
     public function testPutOk()
     {
-        $dao = new _Dao($this->connector);
+        $dao = $this->newTestedInstance($this->connector);
 
-        $put = $dao->put([
-            'planning_id' => 83,
-            'jour_id' => 27,
-            'type_semaine' => 2,
-            'type_periode' => 52,
-            'debut' => 31,
-            'fin' => 91,
-        ], 22);
+        $put = $dao->put(new CreneauEntite($this->entiteContent));
 
         $this->variable($put)->isNull();
     }
 
-    /**
-     * Teste la méthode delete quand tout est ok
-     */
-    public function testDeleteOk()
-    {
-        $this->calling($this->result)->rowCount = 1;
-        $this->newTestedInstance($this->connector);
+    private $storageContent = [
+        'creneau_id' => 42,
+        'planning_id' => 12,
+        'jour_id' => 7,
+        'type_semaine' => 23,
+        'type_periode' => 2,
+        'debut' => 63,
+        'fin' => 55,
+    ];
 
-        $res = $this->testedInstance->delete(7);
-
-        $this->variable($res)->isNull();
-    }
+    private $entiteContent = [
+        'id' => 42,
+        'planningId' => 12,
+        'jourId' => 7,
+        'typeSemaine' => 23,
+        'typePeriode' => 2,
+        'debut' => 63,
+        'fin' => 55,
+    ];
 }

--- a/Tests/Units/Planning/Creneau/CreneauRepository.php
+++ b/Tests/Units/Planning/Creneau/CreneauRepository.php
@@ -1,8 +1,6 @@
 <?php
 namespace LibertAPI\Tests\Units\Planning\Creneau;
 
-use LibertAPI\Planning\Creneau\CreneauEntite;
-
 /**
  * Classe de test du repository de créneau de planning
  *
@@ -22,7 +20,7 @@ final class CreneauRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
 
     protected function initEntite()
     {
-        $this->entite = new CreneauEntite(['id' => 42]);
+        $this->entite = new \LibertAPI\Planning\Creneau\CreneauEntite(['id' => 42]);
     }
 
     /*************************************************

--- a/Tests/Units/Planning/Creneau/CreneauRepository.php
+++ b/Tests/Units/Planning/Creneau/CreneauRepository.php
@@ -1,7 +1,7 @@
 <?php
 namespace LibertAPI\Tests\Units\Planning\Creneau;
 
-use \LibertAPI\Planning\Creneau\CreneauRepository as _Repository;
+use LibertAPI\Planning\Creneau\CreneauEntite;
 
 /**
  * Classe de test du repository de créneau de planning
@@ -11,100 +11,18 @@ use \LibertAPI\Planning\Creneau\CreneauRepository as _Repository;
  *
  * @since 0.1
  */
-final class CreneauRepository extends \Atoum
+final class CreneauRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
 {
-    /**
-     * @var \LibertAPI\Planning\Creneau\CreneauDao Mock du DAO du créneau
-     */
-    private $dao;
-
-    /**
-     * @var \LibertAPI\Planning\Creneau\CreneauEntite Mock de l'Entité de créneau
-     */
-    private $entite;
-
-    public function beforeTestMethod($method)
+    protected function initDao()
     {
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\LibertAPI\Planning\Creneau\CreneauDao();
-        $this->mockGenerator->orphanize('__construct');
-        $this->entite = new \mock\LibertAPI\Planning\Creneau\CreneauEntite();
-        $this->entite->getMockController()->getId = 42;
     }
 
-    /*************************************************
-    * GET
-    *************************************************/
-
-    /**
-     * Teste la méthode getOne avec un id non trouvé
-     */
-    public function testGetOneNotFound()
+    protected function initEntite()
     {
-        $this->dao->getMockController()->getById = [];
-        $repository = new _Repository($this->dao);
-
-        $this->exception(function () use ($repository) {
-            $repository->getOne(99, 23);
-        })->isInstanceOf('\DomainException');
-    }
-
-    /**
-     * Teste la méthode getOne avec un id trouvé
-     */
-    public function testGetOneFound()
-    {
-        $this->dao->getMockController()->getById = [
-            'creneau_id' => '42',
-            'planning_id' => 99,
-            'jour_id' => 99,
-            'type_semaine' => 99,
-            'type_periode' => 99,
-            'debut' => 99,
-            'fin' => 99,
-        ];
-        $repository = new _Repository($this->dao);
-
-        $entite = $repository->getOne(42, 23);
-
-        $this->object($entite)->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
-        $this->integer($entite->getId())->isIdenticalTo(42);
-    }
-
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->dao->getMockController()->getList = [];
-        $repository = new _Repository($this->dao);
-
-        $this->exception(function () use ($repository) {
-            $repository->getList(['planningId' => 58]);
-        })->isInstanceOf('\UnexpectedValueException');
-    }
-
-    /**
-     * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->dao->getMockController()->getList = [[
-            'creneau_id' => '42',
-            'planning_id' => 99,
-            'jour_id' => 99,
-            'type_semaine' => 99,
-            'type_periode' => 99,
-            'debut' => 99,
-            'fin' => 99,
-        ]];
-        $repository = new _Repository($this->dao);
-
-        $entites = $repository->getList(['planningId' => 53]);
-
-        $this->array($entites)->hasKey(42);
-        $this->object($entites[42])->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
+        $this->entite = new CreneauEntite(['id' => 42]);
     }
 
     /*************************************************
@@ -116,7 +34,7 @@ final class CreneauRepository extends \Atoum
      */
     public function testPostListException()
     {
-        $repository = new _Repository($this->dao);
+        $repository = $this->newTestedInstance($this->dao);
         $entite = new \mock\LibertAPI\Planning\Creneau\CreneauEntite([]);
         $entite->getMockController()->populate = function () {
             throw new \LogicException('');
@@ -140,7 +58,7 @@ final class CreneauRepository extends \Atoum
      */
     public function testPostListOk()
     {
-        $repository = new _Repository($this->dao);
+        $repository = $this->newTestedInstance($this->dao);
         $entite = new \mock\LibertAPI\Planning\Creneau\CreneauEntite([]);
         $entite->getMockController()->populate = '';
         $entite->getMockController()->getPlanningId = 3;
@@ -170,132 +88,17 @@ final class CreneauRepository extends \Atoum
         }
     }
 
-    /**
-     * Teste la méthode postOne avec un champ manquant
-     */
-    public function testPostOneMissingArgument()
+    protected function getEntiteContent()
     {
-        $repository = new _Repository($this->dao);
-        $entite = new \mock\LibertAPI\Planning\Creneau\CreneauEntite([]);
-
-        $this->exception(function () use ($repository, $entite) {
-            $repository->postOne([], $entite);
-        })->isInstanceOf('\LibertAPI\Tools\Exceptions\MissingArgumentException');
-    }
-
-    /**
-     * Teste la méthode postOne avec un champ incohérent
-     */
-    public function testPostOneBadDomain()
-    {
-        $repository = new _Repository($this->dao);
-        $entite = new \mock\LibertAPI\Planning\Creneau\CreneauEntite([]);
-        $entite->getMockController()->populate = function () {
-            throw new \DomainException('');
-        };
-        $data = [
-            'planningId' => 34,
-            'jourId' => 23,
-            'typeSemaine' => 15,
-            'typePeriode' => 57,
-            'debut' => 83,
-            'fin' => 92,
-        ];
-
-        $this->exception(function () use ($repository, $data, $entite) {
-            $repository->postOne($data, $entite);
-        })->isInstanceOf('\DomainException');
-    }
-
-    /**
-     * Teste la méthode postOne tout ok
-     */
-    public function testPostOneOk()
-    {
-        $repository = new _Repository($this->dao);
-        $entite = new \mock\LibertAPI\Planning\Creneau\CreneauEntite([]);
-        $entite->getMockController()->populate = '';
-        $entite->getMockController()->getPlanningId = 3;
-        $entite->getMockController()->getJourId = 4;
-        $entite->getMockController()->getTypeSemaine = 5;
-        $entite->getMockController()->getTypePeriode = 6;
-        $entite->getMockController()->getDebut = 7;
-        $entite->getMockController()->getFin = 8;
-        $data = [
-            'planningId' => 34,
-            'jourId' => 2,
-            'typeSemaine' => 0,
+        return [
+            'id' => 42,
+            'planningId' => 12,
+            'jourId' => 7,
+            'typeSemaine' => 23,
             'typePeriode' => 2,
-            'debut' => 83,
-            'fin' => 92,
+            'debut' => 63,
+            'fin' => 55,
         ];
-        $this->dao->getMockController()->post = 3;
-
-        $post = $repository->postOne($data, $entite);
-
-        $this->integer($post);
-    }
-
-    /*************************************************
-     * PUT
-     *************************************************/
-
-    /**
-     * Teste la méthode putOne avec un champ manquant
-     */
-    public function testPutOneMissingArgument()
-    {
-        $repository = new _Repository($this->dao);
-
-        $this->exception(function () use ($repository) {
-            $repository->putOne(['planningId' => 4], new \mock\LibertAPI\Planning\Creneau\CreneauEntite([]));
-        })->isInstanceOf('\LibertAPI\Tools\Exceptions\MissingArgumentException');
-    }
-
-    /**
-     * Teste la méthode putOne avec un champ incohérent
-     */
-    public function testPutOneBadDomain()
-    {
-        $repository = new _Repository($this->dao);
-        $entite = new \mock\LibertAPI\Planning\Creneau\CreneauEntite([]);
-        $entite->getMockController()->populate = function () {
-            throw new \DomainException('');
-        };
-
-        $this->exception(function () use ($repository, $entite) {
-            $repository->putOne(
-                [
-                    'planningId' => 4,
-                    'jourId' => 9,
-                    'typeSemaine' => 3,
-                    'typePeriode' => 4,
-                    'debut' => 3,
-                    'fin' => 129,
-                ],
-                $entite);
-        })->isInstanceOf('\DomainException');
-    }
-
-    /**
-     * Teste la méthode putOne tout ok
-     */
-    public function testPutOneOk()
-    {
-        $repository = new _Repository($this->dao);
-
-        $result = $repository->putOne(
-            [
-                'planningId' => 8,
-                'jourId' => 19,
-                'typeSemaine' => 5,
-                'typePeriode' => 8,
-                'debut' => 37,
-                'fin' => 129,
-            ],
-            $this->entite);
-
-        $this->variable($result)->isNull();
     }
 
     /**

--- a/Tests/Units/Planning/PlanningController.php
+++ b/Tests/Units/Planning/PlanningController.php
@@ -17,7 +17,6 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
     protected function initRepository()
     {
         $this->mockGenerator->orphanize('__construct');
-        $this->mockGenerator->shuntParentClassCalls();
         $this->repository = new \mock\LibertAPI\Planning\PlanningRepository();
     }
 
@@ -311,6 +310,7 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
     public function testDeleteOk()
     {
         $this->repository->getMockController()->getOne = $this->entite;
+        $this->repository->getMockController()->deleteOne = '';
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
         $response = $this->testedInstance->delete($this->request, $this->response, ['planningId' => 99]);

--- a/Tests/Units/Planning/PlanningDao.php
+++ b/Tests/Units/Planning/PlanningDao.php
@@ -3,6 +3,8 @@ namespace LibertAPI\Tests\Units\Planning;
 
 use LibertAPI\Planning\PlanningDao as _Dao;
 
+use LibertAPI\Planning\PlanningEntite;
+
 /**
  * Classe de test du DAO de planning
  *
@@ -13,11 +15,6 @@ use LibertAPI\Planning\PlanningDao as _Dao;
  */
 final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
 {
-    /*************************************************
-     * GET
-     *************************************************/
-
-
     /*************************************************
      * POST
      *************************************************/
@@ -30,10 +27,7 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->calling($this->connector)->lastInsertId = 314;
         $dao = new _Dao($this->connector);
 
-        $postId = $dao->post([
-            'name' => 'name',
-            'status' => 59,
-        ]);
+        $postId = $dao->post(new PlanningEntite($this->entiteContent));
 
         $this->integer($postId)->isIdenticalTo(314);
     }
@@ -49,11 +43,21 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     {
         $dao = new _Dao($this->connector);
 
-        $put = $dao->put([
-            'name' => 'name',
-            'status' => 59,
-        ], 12);
+        $put = $dao->put(new PlanningEntite($this->entiteContent));
 
         $this->variable($put)->isNull();
     }
+
+
+    private $storageContent = [
+        'planning_id' => 72,
+        'name' => 'name',
+        'status' => 59,
+    ];
+
+    private $entiteContent = [
+        'id' => 72,
+        'name' => 'name',
+        'status' => 59,
+    ];
 }

--- a/Tests/Units/Planning/PlanningDao.php
+++ b/Tests/Units/Planning/PlanningDao.php
@@ -48,12 +48,14 @@ final class PlanningDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->variable($put)->isNull();
     }
 
-
-    private $storageContent = [
-        'planning_id' => 72,
-        'name' => 'name',
-        'status' => 59,
-    ];
+    protected function getStorageContent()
+    {
+        return [
+            'planning_id' => 42,
+            'name' => 'name',
+            'status' => 59,
+        ];
+    }
 
     private $entiteContent = [
         'id' => 72,

--- a/Tests/Units/Planning/PlanningRepository.php
+++ b/Tests/Units/Planning/PlanningRepository.php
@@ -11,187 +11,18 @@ use \LibertAPI\Planning\PlanningRepository as _Repository;
  *
  * @since 0.1
  */
-final class PlanningRepository extends \Atoum
+final class PlanningRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
 {
-    /**
-     * @var \LibertAPI\Planning\PlanningDao Mock du DAO du planning
-     */
-    private $dao;
-
-    /**
-     * @var \LibertAPI\Planning\PlanningEntite Mock de l'Entité de planning
-     */
-    private $entite;
-
-    public function beforeTestMethod($method)
+    protected function initDao()
     {
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->dao = new \mock\LibertAPI\Planning\PlanningDao();
-        $this->mockGenerator->orphanize('__construct');
-        $this->entite = new \mock\LibertAPI\Planning\PlanningEntite();
-        $this->entite->getMockController()->getId = 42;
-        $this->entite->getMockController()->getName = 12;
-        $this->entite->getMockController()->getStatus = 12;
     }
 
-    /*************************************************
-     * GET
-     *************************************************/
-
-    /**
-     * Teste la méthode getOne avec un id non trouvé
-     */
-    public function testGetOneNotFound()
+    protected function initEntite()
     {
-        $this->dao->getMockController()->getById = [];
-        $repository = new _Repository($this->dao);
-
-        $this->exception(function () use ($repository) {
-            $repository->getOne(99);
-        })->isInstanceOf('\DomainException');
-    }
-
-    /**
-     * Teste la méthode getOne avec un id trouvé
-     */
-    public function testGetOneFound()
-    {
-        $this->dao->getMockController()->getById = [
-            'planning_id' => '42',
-            'name' => 'H2G2',
-            'status' => '8',
-        ];
-        $repository = new _Repository($this->dao);
-
-        $entite = $repository->getOne(42);
-
-        $this->object($entite)->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
-        $this->integer($entite->getId())->isIdenticalTo(42);
-    }
-
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->dao->getMockController()->getList = [];
-        $repository = new _Repository($this->dao);
-
-        $this->exception(function () use ($repository) {
-            $repository->getList([]);
-        })->isInstanceOf('\UnexpectedValueException');
-    }
-
-    /**
-     * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->dao->getMockController()->getList = [[
-            'planning_id' => '42',
-            'name' => 'H2G2',
-            'status' => '8',
-        ]];
-        $repository = new _Repository($this->dao);
-
-        $entites = $repository->getList([]);
-
-        $this->array($entites)->hasKey(42);
-        $this->object($entites[42])->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
-    }
-
-    /*************************************************
-     * POST
-     *************************************************/
-
-    /**
-     * Teste la méthode postOne avec un champ manquant
-     */
-    public function testPostOneMissingArg()
-    {
-        $repository = new _Repository($this->dao);
-
-        $this->exception(function () use ($repository) {
-            $repository->postOne(['name' => 'bob'], new \mock\LibertAPI\Planning\PlanningEntite([]));
-        })->isInstanceOf('\LibertAPI\Tools\Exceptions\MissingArgumentException');
-    }
-
-    /**
-     * Teste la méthode postOne avec un champ incohérent
-     */
-    public function testPostOneBadDomain()
-    {
-        $repository = new _Repository($this->dao);
-        $entite = new \mock\LibertAPI\Planning\PlanningEntite([]);
-        $entite->getMockController()->populate = function () {
-            throw new \DomainException('');
-        };
-
-        $this->exception(function () use ($repository, $entite) {
-            $repository->postOne(['name' => 'bob', 'status' => 'bab'], $entite);
-        })->isInstanceOf('\DomainException');
-    }
-
-    /**
-     * Teste la méthode postOne quand tout est ok
-     */
-    public function testPostOneOk()
-    {
-        $repository = new _Repository($this->dao);
-        $entite = new \mock\LibertAPI\Planning\PlanningEntite([]);
-        $entite->getMockController()->populate = '';
-        $entite->getMockController()->getName = 'name';
-        $entite->getMockController()->getStatus = 'status';
-        $this->dao->getMockController()->post = 3;
-
-        $post = $repository->postOne(['name' => 'bob', 'status' => 'pop'], $entite);
-
-        $this->integer($post);
-    }
-
-    /*************************************************
-     * PUT
-     *************************************************/
-
-    /**
-     * Teste la méthode putOne avec un champ manquant
-     */
-    public function testPutOneMissingArgument()
-    {
-        $repository = new _Repository($this->dao);
-
-        $this->exception(function () use ($repository) {
-            $repository->putOne(['name' => 'bob'], new \mock\LibertAPI\Planning\PlanningEntite([]));
-        })->isInstanceOf('\LibertAPI\Tools\Exceptions\MissingArgumentException');
-    }
-
-    /**
-     * Teste la méthode putOne avec un champ incohérent
-     */
-    public function testPutOneBadDomain()
-    {
-        $repository = new _Repository($this->dao);
-        $entite = new \mock\LibertAPI\Planning\PlanningEntite([]);
-        $entite->getMockController()->populate = function () {
-            throw new \DomainException('');
-        };
-
-        $this->exception(function () use ($repository, $entite) {
-            $repository->putOne(['name' => 'bob', 'status' => 'bab'], $entite);
-        })->isInstanceOf('\DomainException');
-    }
-
-    /**
-     * Teste la méthode putOne tout ok
-     */
-    public function testPutOneOk()
-    {
-        $repository = new _Repository($this->dao);
-
-        $result = $repository->putOne(['name' => 'baba', 'status' => 4], $this->entite);
-
-        $this->variable($result)->isNull();
+        $this->entite = new \LibertAPI\Planning\PlanningEntite([]);
     }
 
     /*************************************************
@@ -209,7 +40,7 @@ final class PlanningRepository extends \Atoum
         $repository = new _Repository($this->dao);
 
         $this->exception(function () use ($repository) {
-            $repository->deleteOne(new \mock\LibertAPI\Planning\PlanningEntite([]));
+            $repository->deleteOne($this->entite);
         })->isInstanceOf('\LogicException');
 
     }
@@ -221,8 +52,16 @@ final class PlanningRepository extends \Atoum
     {
         $this->dao->getMockController()->delete = 4;
         $repository = new _Repository($this->dao);
-        $entite = new \mock\LibertAPI\Planning\PlanningEntite([]);
 
-        $this->variable($repository->deleteOne($entite))->isNull();
+        $this->variable($repository->deleteOne($this->entite))->isNull();
+    }
+
+    protected function getEntiteContent()
+    {
+        return [
+            'id' => 72,
+            'name' => 'name',
+            'status' => 59,
+        ];
     }
 }

--- a/Tests/Units/Tools/Libraries/ADao.php
+++ b/Tests/Units/Tools/Libraries/ADao.php
@@ -1,6 +1,8 @@
 <?php
 namespace LibertAPI\Tests\Units\Tools\Libraries;
 
+use LibertAPI\Tools\Libraries\AEntite;
+
 /**
  * Classe commune de test du DAO
  *
@@ -55,9 +57,9 @@ abstract class ADao extends \Atoum
         $this->calling($this->result)->fetch = [];
         $this->newTestedInstance($this->connector);
 
-        $get = $this->testedInstance->getById(99);
-
-        $this->array($get)->isEmpty();
+        $this->exception(function () {
+            $this->testedInstance->getById(99);
+        })->isInstanceOf(\DomainException::class);
     }
 
     /**
@@ -65,12 +67,12 @@ abstract class ADao extends \Atoum
      */
     public function testGetByIdFound()
     {
-        $this->calling($this->result)->fetch = ['a'];
+        $this->calling($this->result)->fetch = $this->getStorageContent();
         $this->newTestedInstance($this->connector);
 
         $get = $this->testedInstance->getById(99);
 
-        $this->array($get)->isNotEmpty();
+        $this->object($get)->isInstanceOf(AEntite::class);
     }
 
     /**
@@ -81,9 +83,9 @@ abstract class ADao extends \Atoum
         $this->calling($this->result)->fetchAll = [];
         $this->newTestedInstance($this->connector);
 
-        $get = $this->testedInstance->getList([]);
-
-        $this->array($get)->isEmpty();
+        $this->exception(function () {
+            $this->testedInstance->getList([]);
+        })->isInstanceOf(\UnexpectedValueException::class);
     }
 
     /**
@@ -91,13 +93,18 @@ abstract class ADao extends \Atoum
      */
     public function testGetListFound()
     {
-        $this->calling($this->result)->fetchAll = [['a']];
+        $this->calling($this->result)->fetchAll = [$this->getStorageContent()];
         $this->newTestedInstance($this->connector);
 
         $get = $this->testedInstance->getList([]);
 
-        $this->array($get[0])->isNotEmpty();
+        $this->array($get)->isNotEmpty();
+        array_map(function ($entite) {
+            $this->object($entite)->isInstanceOf(AEntite::class);
+        }, $get);
     }
+
+    abstract protected function getStorageContent();
 
     /**
      * Teste la méthode delete quand tout est ok

--- a/Tests/Units/Tools/Libraries/ARepository.php
+++ b/Tests/Units/Tools/Libraries/ARepository.php
@@ -23,6 +23,7 @@ abstract class ARepository extends \Atoum
 
     public function beforeTestMethod($method)
     {
+        parent::beforeTestMethod($method);
         $this->initDao();
         $this->initEntite();
     }

--- a/Tests/Units/Tools/Libraries/ARepository.php
+++ b/Tests/Units/Tools/Libraries/ARepository.php
@@ -1,0 +1,91 @@
+<?php
+namespace LibertAPI\Tests\Units\Tools\Libraries;
+
+/**
+ * Classe de test des repositories
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.6
+ */
+abstract class ARepository extends \Atoum
+{
+    /**
+     * @var \LibertAPI\Tools\Libraries\ADao
+     */
+    protected $dao;
+
+    /**
+     * @var \LibertAPI\Tools\Libraries\AEntite
+     */
+    protected $entite;
+
+    public function beforeTestMethod($method)
+    {
+        $this->initDao();
+        $this->initEntite();
+    }
+
+    abstract protected function initDao();
+
+    abstract protected function initEntite();
+
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * Teste la méthode getOne
+     */
+    public function testGetOne()
+    {
+        $this->dao->getMockController()->getById = new \stdClass;
+        $repository = $this->newTestedInstance($this->dao);
+
+        $entite = $repository->getOne(42);
+
+        $this->object($entite);
+    }
+
+    /**
+     * Teste la méthode getList
+     */
+    public function testGetList()
+    {
+        $this->calling($this->dao)->getList = [42 => new \stdClass];
+        $repository = $this->newTestedInstance($this->dao);
+
+        $entites = $repository->getList([]);
+
+        $this->array($entites)->hasKey(42);
+        $this->object($entites[42]);
+    }
+
+    /**
+     * Teste la méthode postOne
+     */
+    public function testPostOne()
+    {
+        $repository = $this->newTestedInstance($this->dao);
+        $this->calling($this->dao)->post = 768;
+
+        $post = $repository->postOne($this->getEntiteContent(), $this->entite);
+
+        $this->integer($post)->isIdenticalTo(768);
+    }
+
+    /**
+     * Teste la méthode putOne
+     */
+    public function testPutOne()
+    {
+        $repository = $this->newTestedInstance($this->dao);
+
+        $put = $repository->putOne($this->getEntiteContent(), $this->entite);
+
+        $this->variable($put)->isNull();
+    }
+
+    abstract protected function getEntiteContent();
+}

--- a/Tests/Units/Utilisateur/UtilisateurDao.php
+++ b/Tests/Units/Utilisateur/UtilisateurDao.php
@@ -3,6 +3,8 @@ namespace LibertAPI\Tests\Units\Utilisateur;
 
 use \LibertAPI\Utilisateur\UtilisateurDao as _Dao;
 
+use LibertAPI\Utilisateur\UtilisateurEntite;
+
 /**
  * Classe de test du DAO de l'utilisateur
  *
@@ -44,7 +46,7 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     public function testPost()
     {
         $dao = new _Dao($this->connector);
-        $this->variable($dao->post([]))->isNull();
+        $this->variable($dao->post(new UtilisateurEntite($this->entiteContent)))->isNull();
     }
 
     /*************************************************
@@ -58,10 +60,7 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
     {
         $dao = new _Dao($this->connector);
 
-        $put = $dao->put([
-            'token' => 'token',
-            'date_last_access' => 'date_last_access',
-        ], 'Aladdin');
+        $put = $dao->put(new UtilisateurEntite($this->entiteContent));
 
         $this->variable($put)->isNull();
     }
@@ -82,4 +81,31 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
 
         $this->variable($res)->isNull();
     }
+
+    private $storageContent = [
+        'id' => 'Aladdin',
+        'token' => 'token',
+        'date_last_access' => 'date_last_access',
+        'u_login' => 'Aladdin',
+        'u_prenom' => 'Aladdin',
+        'u_nom' => 'Genie',
+        'u_is_resp' => 'Y',
+        'u_is_admin' => 'Y',
+        'u_is_hr' => 'N',
+        'u_is_active' => 'Y',
+        'u_see_all' => 'Y',
+        'u_passwd' => 'Sésame Ouvre toi',
+        'u_quotite' => '21220',
+        'u_email' => 'aladdin@example.org',
+        'u_num_exercice' => '3',
+        'planning_id' => 12,
+        'u_heure_solde' => 1,
+        'date_inscription' => 123456789,
+    ];
+
+    private $entiteContent = [
+        'id' => 'Aladdin',
+        'token' => 'token',
+        'dateLastAccess' => 'date_last_access',
+    ];
 }

--- a/Tests/Units/Utilisateur/UtilisateurDao.php
+++ b/Tests/Units/Utilisateur/UtilisateurDao.php
@@ -82,26 +82,29 @@ final class UtilisateurDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->variable($res)->isNull();
     }
 
-    private $storageContent = [
-        'id' => 'Aladdin',
-        'token' => 'token',
-        'date_last_access' => 'date_last_access',
-        'u_login' => 'Aladdin',
-        'u_prenom' => 'Aladdin',
-        'u_nom' => 'Genie',
-        'u_is_resp' => 'Y',
-        'u_is_admin' => 'Y',
-        'u_is_hr' => 'N',
-        'u_is_active' => 'Y',
-        'u_see_all' => 'Y',
-        'u_passwd' => 'Sésame Ouvre toi',
-        'u_quotite' => '21220',
-        'u_email' => 'aladdin@example.org',
-        'u_num_exercice' => '3',
-        'planning_id' => 12,
-        'u_heure_solde' => 1,
-        'date_inscription' => 123456789,
-    ];
+    protected function getStorageContent()
+    {
+        return [
+            'id' => 'Aladdin',
+            'token' => 'token',
+            'date_last_access' => 'date_last_access',
+            'u_login' => 'Aladdin',
+            'u_prenom' => 'Aladdin',
+            'u_nom' => 'Genie',
+            'u_is_resp' => 'Y',
+            'u_is_admin' => 'Y',
+            'u_is_hr' => 'N',
+            'u_is_active' => 'Y',
+            'u_see_all' => 'Y',
+            'u_passwd' => 'Sésame Ouvre toi',
+            'u_quotite' => '21220',
+            'u_email' => 'aladdin@example.org',
+            'u_num_exercice' => '3',
+            'planning_id' => 12,
+            'u_heure_solde' => 1,
+            'date_inscription' => 123456789,
+        ];
+    }
 
     private $entiteContent = [
         'id' => 'Aladdin',

--- a/Tests/Units/Utilisateur/UtilisateurRepository.php
+++ b/Tests/Units/Utilisateur/UtilisateurRepository.php
@@ -1,6 +1,7 @@
 <?php
 namespace LibertAPI\Tests\Units\Utilisateur;
 
+use LibertAPI\Utilisateur\UtilisateurEntite;
 use LibertAPI\Utilisateur\UtilisateurRepository as _Repository;
 use LibertAPI\Tools\Libraries\AEntite;
 
@@ -12,17 +13,12 @@ use LibertAPI\Tools\Libraries\AEntite;
  *
  * @since 0.2
  */
-final class UtilisateurRepository extends \Atoum
+final class UtilisateurRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
 {
     /**
      * @var \LibertAPI\Tools\Libraries\Application Mock de la bibliothèque d'application
      */
     private $application;
-
-    /**
-     * @var \LibertAPI\Utilisateur\Dao Mock du DAO de l'utilisateur
-     */
-    private $dao;
 
     /**
      * @var \Doctrine\DBAL\Connection Mock du connecteur
@@ -34,17 +30,10 @@ final class UtilisateurRepository extends \Atoum
      */
     private $statement;
 
-    /**
-     * @var \LibertAPI\Utilisateur\Entite Mock de l'Entité de l'utilisateur
-     */
-    private $entite;
-
     public function beforeTestMethod($method)
     {
         parent::beforeTestMethod($method);
-        $this->mockGenerator->orphanize('__construct');
-        $this->mockGenerator->shuntParentClassCalls();
-        $this->dao = new \mock\LibertAPI\Utilisateur\UtilisateurDao();
+
         $this->mockGenerator->orphanize('__construct');
         $this->mockGenerator->shuntParentClassCalls();
         $this->statement = new \mock\Doctrine\DBAL\Statement();
@@ -54,6 +43,18 @@ final class UtilisateurRepository extends \Atoum
         $this->connector->getMockController()->query = $this->statement;
         $this->mockGenerator->orphanize('__construct');
         $this->application = new \mock\LibertAPI\Tools\Libraries\Application($this->connector);
+
+    }
+
+    protected function initDao()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $this->dao = new \mock\LibertAPI\Utilisateur\UtilisateurDao();
+    }
+
+    protected function initEntite()
+    {
         $this->mockGenerator->orphanize('__construct');
         $this->entite = new \mock\LibertAPI\Utilisateur\UtilisateurEntite();
         $this->entite->getMockController()->getNom = 'Aladdin';
@@ -89,84 +90,12 @@ final class UtilisateurRepository extends \Atoum
      * GET
      *************************************************/
 
-    public function testGetOne()
-    {
-        $this->variable((new _Repository($this->dao))->getOne(1))->isNull();
-    }
-
     /**
      * Teste la méthode find avec des critères pertinents
      */
     public function testFind()
     {
-        $this->dao->getMockController()->getList = [
-            [
-                'id' => 'Aladdin',
-                'u_login' => 'Aladdin',
-                'u_passwd' => 'OpenSesame',
-                'u_nom' => 'Aladdin',
-                'u_prenom' => 'Aladdin',
-                'u_is_resp' => 'Y',
-                'u_is_admin' => 'N',
-                'u_is_hr' => 'N',
-                'u_is_active' => 'N',
-                'u_see_all' => 'N',
-                'u_quotite' => 1000,
-                'u_email' => 'aladdin@tapisvolant.net',
-                'u_num_exercice' => 98,
-                'planning_id' => 12,
-                'u_heure_solde' => 983,
-                'date_inscription' => 2,
-                'token' => '',
-                'date_last_access' => 3,
-            ],
-            [
-                'id' => 'Sinbad',
-                'u_login' => 'Sinbad',
-                'u_nom' => 'Sinbad',
-                'u_prenom' => 'Sinbad',
-                'u_is_resp' => 'N',
-                'u_is_admin' => 'N',
-                'u_is_hr' => 'N',
-                'u_is_active' => 'N',
-                'u_see_all' => 'N',
-                'u_passwd' => 'Bassorah',
-                'u_quotite' => 1000,
-                'u_email' => 'sinbad@sea.com',
-                'u_num_exercice' => 5,
-                'planning_id' => 12,
-                'u_heure_solde' => 1218,
-                'date_inscription' => 2,
-                'token' => '',
-                'date_last_access' => 134,
-            ],
-        ];
-        $repository = new _Repository($this->dao);
-
-        $entite = $repository->find([]);
-
-        $this->object($entite)->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
-    }
-
-    /**
-     * Teste la méthode getList avec des critères non pertinents
-     */
-    public function testGetListNotFound()
-    {
-        $this->dao->getMockController()->getList = [];
-        $repository = new _Repository($this->dao);
-
-        $this->exception(function () use ($repository) {
-            $repository->getList([]);
-        })->isInstanceOf('\UnexpectedValueException');
-    }
-
-    /**
-     * Teste la méthode getList avec des critères pertinents
-     */
-    public function testGetListFound()
-    {
-        $this->dao->getMockController()->getList = [[
+        $this->calling($this->dao)->getList = ['Aladdin' => new UtilisateurEntite([
             'id' => 'Aladdin',
             'u_login' => 'Aladdin',
             'u_passwd' => 'OpenSesame',
@@ -184,14 +113,33 @@ final class UtilisateurRepository extends \Atoum
             'u_heure_solde' => 983,
             'date_inscription' => 2,
             'token' => '',
-            'date_last_access' => 98,
-        ]];
+            'date_last_access' => 3,
+        ]),
+        'Sinbad' => new UtilisateurEntite([
+            'id' => 'Sinbad',
+            'u_login' => 'Sinbad',
+            'u_nom' => 'Sinbad',
+            'u_prenom' => 'Sinbad',
+            'u_is_resp' => 'N',
+            'u_is_admin' => 'N',
+            'u_is_hr' => 'N',
+            'u_is_active' => 'N',
+            'u_see_all' => 'N',
+            'u_passwd' => 'Bassorah',
+            'u_quotite' => 1000,
+            'u_email' => 'sinbad@sea.com',
+            'u_num_exercice' => 5,
+            'planning_id' => 12,
+            'u_heure_solde' => 1218,
+            'date_inscription' => 2,
+            'token' => '',
+            'date_last_access' => 134,
+        ]),];
         $repository = new _Repository($this->dao);
 
-        $entites = $repository->getList([]);
+        $entite = $repository->find([]);
 
-        $this->array($entites)->hasKey('Aladdin');
-        $this->object($entites['Aladdin'])->isInstanceOf('\LibertAPI\Tools\Libraries\AEntite');
+        $this->object($entite)->isInstanceOf(\LibertAPI\Tools\Libraries\AEntite::class);
     }
 
     /*************************************************
@@ -207,11 +155,6 @@ final class UtilisateurRepository extends \Atoum
     /*************************************************
      * PUT
      *************************************************/
-
-    public function testPutOne()
-    {
-        $this->variable((new _Repository($this->dao))->putOne([], $this->entite))->isNull();
-    }
 
     public function testUpdateDateLastAccess()
     {
@@ -277,5 +220,11 @@ final class UtilisateurRepository extends \Atoum
     public function testDeleteOne()
     {
         $this->variable((new _Repository($this->dao))->deleteOne($this->entite))->isNull();
+    }
+
+    protected function getEntiteContent()
+    {
+        return [
+        ];
     }
 }

--- a/Tests/Units/Utilisateur/UtilisateurRepository.php
+++ b/Tests/Units/Utilisateur/UtilisateurRepository.php
@@ -1,7 +1,6 @@
 <?php
 namespace LibertAPI\Tests\Units\Utilisateur;
 
-use LibertAPI\Utilisateur\UtilisateurEntite;
 use LibertAPI\Utilisateur\UtilisateurRepository as _Repository;
 use LibertAPI\Tools\Libraries\AEntite;
 
@@ -95,7 +94,7 @@ final class UtilisateurRepository extends \LibertAPI\Tests\Units\Tools\Libraries
      */
     public function testFind()
     {
-        $this->calling($this->dao)->getList = ['Aladdin' => new UtilisateurEntite([
+        $this->calling($this->dao)->getList = ['Aladdin' => new \LibertAPI\Utilisateur\UtilisateurEntite([
             'id' => 'Aladdin',
             'u_login' => 'Aladdin',
             'u_passwd' => 'OpenSesame',
@@ -115,7 +114,7 @@ final class UtilisateurRepository extends \LibertAPI\Tests\Units\Tools\Libraries
             'token' => '',
             'date_last_access' => 3,
         ]),
-        'Sinbad' => new UtilisateurEntite([
+        'Sinbad' => new \LibertAPI\Utilisateur\UtilisateurEntite([
             'id' => 'Sinbad',
             'u_login' => 'Sinbad',
             'u_nom' => 'Sinbad',

--- a/Tools/Libraries/ADao.php
+++ b/Tools/Libraries/ADao.php
@@ -43,9 +43,19 @@ abstract class ADao
      *
      * @param int $id Id potentiel de ressource
      *
-     * @return array, vide si $id n'est pas dans le domaine de définition
+     * @return AEntite
+     * @throws \DomainException si $id n'est pas dans le domaine de définition
      */
     abstract public function getById($id);
+
+    /**
+     * Effectue le mapping des éléments venant de la DAO pour qu'ils soient compréhensibles pour l'Entité
+     *
+     * @param array $dataDao
+     *
+     * @return array
+     */
+    abstract protected function getStorage2Entite(array $dataDao);
 
     /**
      * Retourne une liste de ressource correspondant à des critères
@@ -64,11 +74,11 @@ abstract class ADao
     /**
      * Poste une nouvelle ressource
      *
-     * @param array $data Données à insérer
+     * @param AEntite $entite
      *
      * @return int Id de la ressource nouvellement créée
      */
-    abstract public function post(array $data);
+    abstract public function post(AEntite $entite);
 
     /*************************************************
      * PUT
@@ -77,10 +87,18 @@ abstract class ADao
     /**
      * Met à jour une ressource
      *
-     * @param array $data Données à mettre à jour
-     * @param int $id Id de l'élément à mettre à jour
+     * @param AEntite $entite
      */
-    abstract public function put(array $data, $id);
+    abstract public function put(AEntite $entite);
+
+    /**
+     * Effectue le mapping des éléments venant de l'entité pour qu'ils soient compréhensibles pour la DAO
+     *
+     * @param AEntite $entite
+     *
+     * @return array
+     */
+    abstract protected function getEntite2Storage(AEntite $entite);
 
     /*************************************************
      * DELETE

--- a/Tools/Libraries/AEntite.php
+++ b/Tools/Libraries/AEntite.php
@@ -1,6 +1,8 @@
 <?php
 namespace LibertAPI\Tools\Libraries;
 
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+
 /**
  * Domain Model. Par essence, ne peut pas être immuable.
  *
@@ -26,7 +28,7 @@ abstract class AEntite
     protected $data = [];
 
     /**
-     * @var array $data Données d'édition de l'objet
+     * @var array $dataUpdated Données d'édition de l'objet
      */
     protected $dataUpdated = [];
 
@@ -67,6 +69,7 @@ abstract class AEntite
      *
      * @param array $data Données à insérer / mettre à jour
      *
+     * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si une ou plusieurs données ne sont pas dans les bons domaines de définition, où les erreurs sont jsonEncodée dans le message
      * @example ['nomChamp' => [listeErreurs]]
      */

--- a/Tools/Libraries/ARepository.php
+++ b/Tools/Libraries/ARepository.php
@@ -1,8 +1,6 @@
 <?php
 namespace LibertAPI\Tools\Libraries;
 
-use LibertAPI\Tools\Exceptions\MissingArgumentException;
-
 /**
  * Garant de la cohérence métier de l'entité en relation.
  * Autrement dit, c'est lui qui va chercher les données (dépendances comprises),

--- a/Tools/Libraries/ARepository.php
+++ b/Tools/Libraries/ARepository.php
@@ -37,10 +37,12 @@ abstract class ARepository
      *
      * @param int $id Id potentiel de ressource
      *
-     * @return \Tools\Libraries\AEntite
-     * @throws \DomainException Si $id n'est pas dans le domaine de définition
+     * @return \LibertAPI\Tools\Libraries\AEntite
      */
-    abstract public function getOne($id);
+    public function getOne($id)
+    {
+        return $this->dao->getById((int) $id);
+    }
 
     /**
      * Retourne une liste de ressource correspondant à des critères
@@ -49,18 +51,11 @@ abstract class ARepository
      * @example [offset => 4, start-after => 23, filter => 'name::chapo|status::1,3']
      *
      * @return array [$objetId => $objet]
-     * @throws \UnexpectedValueException Si les critères ne sont pas pertinents
      */
-    abstract public function getList(array $parametres);
-
-    /**
-     * Effectue le mapping des éléments venant de la DAO pour qu'ils soient compréhensibles pour l'Entité
-     *
-     * @param array $dataDao
-     *
-     * @return array
-     */
-    abstract protected function getDataDao2Entite(array $dataDao);
+    public function getList(array $parametres)
+    {
+        return $this->dao->getList($this->getParamsConsumer2Dao($parametres));
+    }
 
     /**
      * Effectue le mapping des recherches du consommateur de l'API pour qu'elles
@@ -75,15 +70,6 @@ abstract class ARepository
      */
     abstract protected function getParamsConsumer2Dao(array $paramsConsumer);
 
-    /**
-     * Effectue le mapping des éléments venant de l'entité pour qu'ils soient compréhensibles pour la DAO
-     *
-     * @param AEntite $entite
-     *
-     * @return array
-     */
-    abstract protected function getEntite2DataDao(AEntite $entite);
-
     /*************************************************
      * POST
      *************************************************/
@@ -95,49 +81,12 @@ abstract class ARepository
      * @param AEntite $entite [Vide par définition]
      *
      * @return int Id de la ressource nouvellement insérée
-     * @throws MissingArgumentException Si un élément requis n'est pas présent
-     * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
     public function postOne(array $data, AEntite $entite)
     {
-        if (!$this->hasAllRequired($data)) {
-            throw new MissingArgumentException('');
-        }
-
-        try {
-            $entite->populate($data);
-            $dataDao = $this->getEntite2DataDao($entite);
-
-            return $this->dao->post($dataDao);
-        } catch (\Exception $e) {
-            throw $e;
-        }
+        $entite->populate($data);
+        return $this->dao->post($entite);
     }
-
-    /**
-     * Vérifie que les données passées possèdent bien tous les champs requis
-     *
-     * @param array $data
-     *
-     * @return bool
-     */
-    protected function hasAllRequired(array $data)
-    {
-        foreach ($this->getListRequired() as $value) {
-            if (!isset($data[$value])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Retourne la liste des champs requis
-     *
-     * @return array
-     */
-    abstract protected function getListRequired();
 
     /*************************************************
      * PUT
@@ -148,24 +97,11 @@ abstract class ARepository
      *
      * @param array $data Données à mettre à jour
      * @param AEntite $entite
-     *
-     * @throws MissingArgumentException Si un élément requis n'est pas présent
-     * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
     public function putOne(array $data, AEntite $entite)
     {
-        if (!$this->hasAllRequired($data)) {
-            throw new MissingArgumentException('');
-        }
-
-        try {
-            $entite->populate($data);
-            $dataDao = $this->getEntite2DataDao($entite);
-
-            return $this->dao->put($dataDao, $entite->getId());
-        } catch (\Exception $e) {
-            throw $e;
-        }
+        $entite->populate($data);
+        $this->dao->put($entite);
     }
 
     /*************************************************

--- a/Tools/Route/Journal.php
+++ b/Tools/Route/Journal.php
@@ -10,7 +10,6 @@
 
 /* Routes sur le journal */
 $app->group('/journal', function () {
-    $journalNS = '\LibertAPI\Journal\JournalController';
     /* Collection */
-    $this->get('', $journalNS .  ':get')->setName('getJournalListe');
+    $this->get('', 'controller:get')->setName('getJournalListe');
 });

--- a/Tools/Route/Utilisateur.php
+++ b/Tools/Route/Utilisateur.php
@@ -2,11 +2,11 @@
 /*
  * Doit être importé après la création de $app. Ne créé rien.
  *
- * La convention de nommage est de mettre les routes au pluriel
+ * La convention de nommage est de mettre les routes au singulier
  */
 
 /* Routes sur l'utilisateur et associés */
-$app->group('/utilisateurs', function () {
+$app->group('/utilisateur', function () {
     $this->group('/{utilisateurId:[0-9]+}', function () {
         /* Detail */
         $this->get('', 'controller:get')->setName('getUtilisateurDetail');

--- a/Utilisateur/UtilisateurController.php
+++ b/Utilisateur/UtilisateurController.php
@@ -1,5 +1,5 @@
 <?php
-namespace App\Components\Utilisateur;
+namespace LibertAPI\Utilisateur;
 
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use Psr\Http\Message\ResponseInterface as IResponse;
@@ -109,11 +109,11 @@ final class UtilisateurController extends \LibertAPI\Tools\Libraries\AController
     /**
      * Construit le « data » du json
      *
-     * @param Entite $entite Utilisateur
+     * @param UtilisateurEntite $entite Utilisateur
      *
      * @return array
      */
-    private function buildData(Entite $entite)
+    private function buildData(UtilisateurEntite $entite)
     {
         return [
             'id' => $entite->getId(),

--- a/Utilisateur/UtilisateurEntite.php
+++ b/Utilisateur/UtilisateurEntite.php
@@ -1,6 +1,8 @@
 <?php
 namespace LibertAPI\Utilisateur;
 
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+
 use LibertAPI\Tools\Helpers\Formatter;
 
 /**
@@ -112,6 +114,9 @@ class UtilisateurEntite extends \LibertAPI\Tools\Libraries\AEntite
      */
     public function populate(array $data)
     {
+        if (!$this->hasAllRequired($data)) {
+            throw new MissingArgumentException('');
+        }
     }
 
     /**

--- a/Utilisateur/UtilisateurRepository.php
+++ b/Utilisateur/UtilisateurRepository.php
@@ -37,10 +37,6 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
      * GET
      *************************************************/
 
-    public function getOne($id)
-    {
-    }
-
     /**
      * Retourne une ressource correspondant à des critères
      *
@@ -53,52 +49,6 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
     {
         $list = $this->getList($parametres);
         return reset($list);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getList(array $parametres)
-    {
-        $data = $this->dao->getList($this->getParamsConsumer2Dao($parametres));
-        if (empty($data)) {
-            throw new \UnexpectedValueException('No resource match with these parameters');
-        }
-
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new UtilisateurEntite($this->getDataDao2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
-
-        return $entites;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getDataDao2Entite(array $dataDao)
-    {
-        return [
-            'id' => $dataDao['id'],
-            'login' => $dataDao['u_login'],
-            'nom' => $dataDao['u_nom'],
-            'prenom' => $dataDao['u_prenom'],
-            'isResp' => $dataDao['u_is_resp'] === 'Y',
-            'isAdmin' => $dataDao['u_is_admin'] === 'Y',
-            'isHr' => $dataDao['u_is_hr'] === 'Y',
-            'isActive' => $dataDao['u_is_active'] === 'Y',
-            'seeAll' => $dataDao['u_see_all'] === 'Y',
-            'password' => $dataDao['u_passwd'],
-            'quotite' => $dataDao['u_quotite'],
-            'email' => $dataDao['u_email'],
-            'numeroExercice' => $dataDao['u_num_exercice'],
-            'planningId' => $dataDao['planning_id'],
-            'heureSolde' => $dataDao['u_heure_solde'],
-            'dateInscription' => $dataDao['date_inscription'],
-            'token' => $dataDao['token'],
-            'dateLastAccess' => $dataDao['date_last_access'],
-        ];
     }
 
     /**
@@ -156,8 +106,7 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
     public function updateDateLastAccess(UtilisateurEntite $entite)
     {
         $entite->updateDateLastAccess();
-        $dataDao = $this->getEntite2DataDao($entite);
-        $this->dao->put($dataDao, $entite->getId());
+        $this->dao->put($entite);
     }
 
     /**
@@ -178,39 +127,12 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
         try {
             $entite->populateToken($this->buildToken($instanceToken));
             $entite->updateDateLastAccess();
-            $dataDao = $this->getEntite2DataDao($entite);
-            $this->dao->put($dataDao, $entite->getId());
+            $this->dao->put($entite);
 
             return $entite;
         } catch (\Exception $e) {
             throw $e;
         }
-    }
-
-    /**
-     * @inheritDoc
-     */
-    final protected function getEntite2DataDao(AEntite $entite)
-    {
-        return [
-            //'u_login' => $entite->getLogin(), // PK ne doit pas être vu par la DAO
-            /*'u_nom' => $entite->getJourId(),
-            'u_prenom' => $entite->getTypeSemaine(),
-            'u_is_resp' => $entite->getTypePeriode(),
-            'u_is_admin' => $entite->getDebut(),
-            'u_is_hr' => $entite->getFin(),
-            'u_is_active' => $entite->getFin(),
-            'u_see_all' => $entite->getFin(),
-            'u_passwd' => $entite->getFin(),
-            'u_quotite' => $entite->getFin(),
-            'u_email' => $entite->getFin(),
-            'u_num_exercice' => $entite->getFin(),
-            'planning_id' => $entite->getFin(),
-            'u_heure_solde' => $entite->getFin(),
-            'date_inscription' => $entite->getFin(),*/
-            'token' => $entite->getToken(),
-            'date_last_access' => $entite->getDateLastAccess(),
-        ];
     }
 
     /**

--- a/Utilisateur/UtilisateurRepository.php
+++ b/Utilisateur/UtilisateurRepository.php
@@ -80,14 +80,6 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
     {
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function getListRequired()
-    {
-        return [];
-    }
-
     /*************************************************
      * PUT
      *************************************************/


### PR DESCRIPTION
Le pattern [DAO](https://fr.wikipedia.org/wiki/Objet_d%27acc%C3%A8s_aux_donn%C3%A9es) a été choisi pour les échanges avec le stockage des informations habituelles. Ce dernier décrit un contrat clair d'accès à la donnée et permet ainsi de s'abstraire de la façon dont les données sont récupérées. Appuyés sur les contrats, nous pouvons ainsi changer le mécanisme du stockage actuel pour des fichiers plats, un nosql, etc. et ceci sans que le reste de l'application n'en soit affecté.
À cette fin d'abstraction, il est essentiel que la DAO retourne un élément qui a un sens applicatif, et non pas quelques chose qui a un sens associé au stockage choisi, dans notre cas une entité.

Je n'ai pas fait les choses dans ce sens et cette PR se propose de corriger ce défaut.

Techniquement, une partie de la responsabilité du Repo a été déporté dans le DAO (la construction de l'entité), la lecture du code ne devrait donc rien montrer de nouveau. Le Repo fond donc comme neige au soleil, et il est possible que les classes Repo filles soient supprimées à terme si elle n'apporte rien de plus au père. Je vais laisser vivre et on verra avec le temps.

Puisque l'on touche à une couche transverse, il faudrait retester toutes les routes pour vérifier que les mécanismes ont bien été implémentés dans chacun des composants. Je cherche actuellement une solution pour vérifier automatiquement les régressions et s'abstenir de tout retester à chacun fois que je change un truc.