### PR TITLE
Ajout de la route pour les groupes

### DIFF
--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -23,6 +23,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
      */
     protected function ensureAccessUser($order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
+        // uniquement accessible par l'admin ?
     }
 
     /**
@@ -44,7 +45,6 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
      * @param int $id ID de l'élément
      *
      * @return IResponse, 404 si l'élément n'est pas trouvé, 200 sinon
-     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
      */
     private function getOne(IResponse $response, $id)
     {

--- a/Absence/Type/TypeDao.php
+++ b/Absence/Type/TypeDao.php
@@ -54,10 +54,6 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
     {
         $this->queryBuilder->select('*');
         $this->setWhere($parametres);
-        if (!empty($parametres['limit'])) {
-            $this->queryBuilder->setFirstResult(0);
-            $this->queryBuilder->setMaxResults((int) $parametres['limit']);
-        }
         $res = $this->queryBuilder->execute();
 
         $data = $res->fetchAll(\PDO::FETCH_ASSOC);
@@ -171,21 +167,13 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
      * Définit les filtres à appliquer à la requête
      *
      * @param array $parametres
-     * @example [filter => [], lt => 23, limit => 4]
+     * @example [filter => []]
      */
     private function setWhere(array $parametres)
     {
         if (!empty($parametres['id'])) {
             $this->queryBuilder->andWhere('ta_id = :id');
             $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
-        }
-        if (!empty($parametres['lt'])) {
-            $this->queryBuilder->andWhere('planning_id < :lt');
-            $this->queryBuilder->setParameter(':lt', (int) $parametres['lt']);
-        }
-        if (!empty($parametres['gt'])) {
-            $this->queryBuilder->andWhere('planning_id > :gt');
-            $this->queryBuilder->setParameter(':gt', (int) $parametres['gt']);
         }
     }
 

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -19,25 +19,8 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function getParamsConsumer2Dao(array $paramsConsumer)
     {
-        $filterInt = function ($var) {
-            return filter_var(
-                $var,
-                FILTER_VALIDATE_INT,
-                ['options' => ['min_range' => 1]]
-            );
-        };
-        $results = [];
-        if (!empty($paramsConsumer['limit'])) {
-            $results['limit'] = $filterInt($paramsConsumer['limit']);
-        }
-        if (!empty($paramsConsumer['start-after'])) {
-            $results['lt'] = $filterInt($paramsConsumer['start-after']);
-
-        }
-        if (!empty($paramsConsumer['start-before'])) {
-            $results['gt'] = $filterInt($paramsConsumer['start-before']);
-        }
-        return $results;
+        unset($paramsConsumer);
+        return [];
     }
 
     /**

--- a/Groupe/GroupeDao.php
+++ b/Groupe/GroupeDao.php
@@ -1,5 +1,5 @@
 <?php
-namespace LibertAPI\Planning;
+namespace LibertAPI\Groupe;
 
 use LibertAPI\Tools\Libraries\AEntite;
 
@@ -9,12 +9,12 @@ use LibertAPI\Tools\Libraries\AEntite;
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.1
+ * @since 0.7
  *
- * Ne devrait être contacté que par PlanningRepository
+ * Ne devrait être contacté que par GroupeRepository
  * Ne devrait contacter personne
  */
-class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
+class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
 {
     /*************************************************
      * GET
@@ -34,7 +34,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
             throw new \DomainException('#' . $id . ' is not a valid resource');
         }
 
-        return new PlanningEntite($this->getStorage2Entite($data));
+        return new GroupeEntite($this->getStorage2Entite($data));
     }
 
     /**
@@ -43,9 +43,10 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     final protected function getStorage2Entite(array $dataDao)
     {
         return [
-            'id' => $dataDao['planning_id'],
-            'name' => $dataDao['name'],
-            'status' => $dataDao['status'],
+            'id' => $dataDao['g_gid'],
+            'name' => $dataDao['g_groupename'],
+            'comment' => $dataDao['g_comment'],
+            'double_validation' => 'Y' === $dataDao['g_double_valid']
         ];
     }
 
@@ -65,7 +66,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
 
         $entites = [];
         foreach ($data as $value) {
-            $entite = new PlanningEntite($this->getStorage2Entite($value));
+            $entite = new GroupeEntite($this->getStorage2Entite($value));
             $entites[$entite->getId()] = $entite;
         }
 
@@ -95,9 +96,11 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
      */
     private function setValues(array $values)
     {
-        $this->queryBuilder->setValue('name', ':name');
+        $this->queryBuilder->setValue('g_groupename', ':name');
         $this->queryBuilder->setParameter(':name', $values['name']);
-        $this->queryBuilder->setValue('status', $values['status']);
+        $this->queryBuilder->setValue('g_comment', $values['comment']);
+        $this->queryBuilder->setValue('g_double_valid', $values['double_validation']);
+
     }
 
     /*************************************************
@@ -111,7 +114,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     {
         $this->queryBuilder->update($this->getTableName());
         $this->setSet($this->getEntite2Storage($entite));
-        $this->queryBuilder->where('planning_id = :id');
+        $this->queryBuilder->where('g_gid = :id');
         $this->queryBuilder->setParameter(':id', $entite->getId());
 
         $this->queryBuilder->execute();
@@ -124,19 +127,24 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     {
         return [
             'name' => $entite->getName(),
-            'status' => $entite->getStatus(),
+            'comment' => $entite->getComment(),
+            'double_validation' => 'Y' === $entite->isDoubleValidated()
         ];
     }
 
     private function setSet(array $parametres)
     {
         if (!empty($parametres['name'])) {
-            $this->queryBuilder->set('name', ':name');
+            $this->queryBuilder->set('g_groupename', ':name');
             $this->queryBuilder->setParameter(':name', $parametres['name']);
         }
-        if (!empty($parametres['status'])) {
-            $this->queryBuilder->set('status', ':status');
-            $this->queryBuilder->setParameter(':status', $parametres['status']);
+        if (!empty($parametres['comment'])) {
+            $this->queryBuilder->set('g_comment', ':comment');
+            $this->queryBuilder->setParameter(':comment', $parametres['comment']);
+        }
+        if (!empty($parametres['double_validation'])) {
+            $this->queryBuilder->set('g_double_valid', ':double_validation');
+            $this->queryBuilder->setParameter(':double_validation', $parametres['double_validation']);
         }
     }
 
@@ -165,7 +173,7 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     private function setWhere(array $parametres)
     {
         if (!empty($parametres['id'])) {
-            $this->queryBuilder->andWhere('planning_id = :id');
+            $this->queryBuilder->andWhere('g_gid = :id');
             $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
         }
     }
@@ -175,6 +183,6 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
      */
     final protected function getTableName()
     {
-        return 'planning';
+        return 'conges_groupe';
     }
 }

--- a/Groupe/GroupeEntite.php
+++ b/Groupe/GroupeEntite.php
@@ -12,7 +12,7 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
  * @since 0.7
  * @see \LibertAPI\Tests\Units\Groupe\GroupeEntite
  *
- * Ne devrait être contacté que par le Groupe\GroupeRepository
+ * Ne devrait être contacté que par le GroupeRepository
  * Ne devrait contacter personne
  */
 class GroupeEntite extends \LibertAPI\Tools\Libraries\AEntite

--- a/Groupe/GroupeEntite.php
+++ b/Groupe/GroupeEntite.php
@@ -1,5 +1,5 @@
 <?php
-namespace LibertAPI\Planning;
+namespace LibertAPI\Groupe;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
 
@@ -9,13 +9,13 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.1
- * @see \LibertAPI\Tests\Units\Planning\PlanningEntite
+ * @since 0.7
+ * @see \LibertAPI\Tests\Units\Groupe\GroupeEntite
  *
- * Ne devrait être contacté que par le Planning\Repository
+ * Ne devrait être contacté que par le Groupe\GroupeRepository
  * Ne devrait contacter personne
  */
-class PlanningEntite extends \LibertAPI\Tools\Libraries\AEntite
+class GroupeEntite extends \LibertAPI\Tools\Libraries\AEntite
 {
     /**
      * Retourne la donnée la plus à jour du champ name
@@ -28,13 +28,23 @@ class PlanningEntite extends \LibertAPI\Tools\Libraries\AEntite
     }
 
     /**
-     * Retourne la donnée la plus à jour du champ status
+     * Retourne la donnée la plus à jour du champ comment
      *
-     * @return int
+     * @return string
      */
-    public function getStatus()
+    public function getComment()
     {
-        return (int) $this->getFreshData('status');
+        return $this->getFreshData('comment');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ de double validation
+     *
+     * @return bool
+     */
+    public function isDoubleValidated()
+    {
+        return (bool) $this->getFreshData('double_validation');
     }
 
     /**
@@ -46,7 +56,8 @@ class PlanningEntite extends \LibertAPI\Tools\Libraries\AEntite
             throw new MissingArgumentException('');
         }
         $this->setName($data['name']);
-        $this->setStatus($data['status']);
+        $this->setComment($data['comment']);
+        $this->withDoubleValidation($data['double_validation']);
 
         $erreurs = $this->getErreurs();
         if (!empty($erreurs)) {
@@ -79,7 +90,7 @@ class PlanningEntite extends \LibertAPI\Tools\Libraries\AEntite
      */
     private function getListRequired()
     {
-        return ['name', 'status'];
+        return ['name', 'comment', 'double_validation'];
     }
 
     /**
@@ -100,22 +111,39 @@ class PlanningEntite extends \LibertAPI\Tools\Libraries\AEntite
         $this->dataUpdated['name'] = $name;
     }
 
-
     /**
-     * Tente l'insertion d'une donnée en tant que champ « status »
+     * Tente l'insertion d'une donnée en tant que champ « comment »
+     * Il ne s'agit que d'une aide pour l'utilisateur
      *
      * Stocke une erreur si la donnée ne colle pas au domaine
      *
-     * @param string $status
+     * @param string $comment
      */
-    private function setStatus($status)
+    private function setComment($comment)
     {
-        // domaine de status ?
-        if (empty($status)) {
-            $this->setErreur('status', 'Le champ est vide');
+        if (empty($comment)) {
+            $this->setErreur('comment', 'Le champ est vide');
             return;
         }
 
-        $this->dataUpdated['status'] = $status;
+        $this->dataUpdated['comment'] = $comment;
+    }
+
+    /**
+     * Tente l'insertion d'une donnée en tant que champ « comment »
+     * Il ne s'agit que d'une aide pour l'utilisateur
+     *
+     * Stocke une erreur si la donnée ne colle pas au domaine
+     *
+     * @param string $doubleValidation enum (Y, N)
+     */
+    private function withDoubleValidation($doubleValidation)
+    {
+        if (empty($doubleValidation)) {
+            $this->setErreur('double_validation', 'Le champ est vide');
+            return;
+        }
+
+        $this->dataUpdated['double_validation'] = 'Y' === $doubleValidation;
     }
 }

--- a/Groupe/GroupeRepository.php
+++ b/Groupe/GroupeRepository.php
@@ -1,0 +1,50 @@
+<?php
+namespace LibertAPI\Groupe;
+
+use LibertAPI\Tools\Libraries\AEntite;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ * @see \LibertAPI\Tests\Units\Planning\PlanningRepository
+ *
+ * Ne devrait être contacté que par le GroupeController
+ * Ne devrait contacter que le GroupeEntite, GroupeDao
+ */
+class GroupeRepository extends \LibertAPI\Tools\Libraries\ARepository
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getParamsConsumer2Dao(array $paramsConsumer)
+    {
+        unset($paramsConsumer);
+        return [];
+    }
+
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteOne(AEntite $entite)
+    {
+        try {
+            $entite->reset();
+            $this->dao->delete($entite->getId());
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+}

--- a/Journal/JournalDao.php
+++ b/Journal/JournalDao.php
@@ -32,10 +32,6 @@ class JournalDao extends \LibertAPI\Tools\Libraries\ADao
     {
         $this->queryBuilder->select('*');
         $this->setWhere($parametres);
-        if (!empty($parametres['limit'])) {
-            $this->queryBuilder->setFirstResult(0);
-            $this->queryBuilder->setMaxResults((int) $parametres['limit']);
-        }
         $res = $this->queryBuilder->execute();
 
         $data = $res->fetchAll(\PDO::FETCH_ASSOC);
@@ -116,21 +112,13 @@ class JournalDao extends \LibertAPI\Tools\Libraries\ADao
      * Définit les filtres à appliquer à la requête
      *
      * @param array $parametres
-     * @example [filter => [], lt => 23, limit => 4]
+     * @example [filter => []]
      */
     private function setWhere(array $parametres)
     {
         if (!empty($parametres['id'])) {
             $this->queryBuilder->andWhere('log_id = :id');
             $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
-        }
-        if (!empty($parametres['lt'])) {
-            $this->queryBuilder->andWhere('log_id < :lt');
-            $this->queryBuilder->setParameter(':lt', (int) $parametres['lt']);
-        }
-        if (!empty($parametres['gt'])) {
-            $this->queryBuilder->andWhere('log_id > :gt');
-            $this->queryBuilder->setParameter(':gt', (int) $parametres['gt']);
         }
     }
 

--- a/Journal/JournalRepository.php
+++ b/Journal/JournalRepository.php
@@ -31,24 +31,8 @@ class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function getParamsConsumer2Dao(array $paramsConsumer)
     {
-        $filterInt = function ($var) {
-            return filter_var(
-                $var,
-                FILTER_VALIDATE_INT,
-                ['options' => ['min_range' => 1]]
-            );
-        };
-        $results = [];
-        if (!empty($paramsConsumer['limit'])) {
-            $results['limit'] = $filterInt($paramsConsumer['limit']);
-        }
-        if (!empty($paramsConsumer['start-after'])) {
-            $results['lt'] = $filterInt($paramsConsumer['start-after']);
-        }
-        if (!empty($paramsConsumer['start-before'])) {
-            $results['gt'] = $filterInt($paramsConsumer['start-before']);
-        }
-        return $results;
+        unset($paramsConsumer);
+        return [];
     }
 
     /*************************************************

--- a/Planning/Creneau/CreneauController.php
+++ b/Planning/Creneau/CreneauController.php
@@ -49,7 +49,6 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable
      * @param int $planningId Contrainte de recherche sur le planning
      *
      * @return IResponse, 404 si l'élément n'est pas trouvé, 200 sinon
-     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
      */
     private function getOne(IResponse $response, $id, $planningId)
     {

--- a/Planning/Creneau/CreneauRepository.php
+++ b/Planning/Creneau/CreneauRepository.php
@@ -34,16 +34,9 @@ class CreneauRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function getParamsConsumer2Dao(array $paramsConsumer)
     {
-        $filterInt = function ($var) {
-            return filter_var(
-                $var,
-                FILTER_VALIDATE_INT,
-                ['options' => ['min_range' => 1]]
-            );
-        };
         $results = [];
         if (!empty($paramsConsumer['planningId'])) {
-            $results['planning_id'] = $filterInt($paramsConsumer['planningId']);
+            $results['planning_id'] = (int) $paramsConsumer['planningId'];
         }
 
         return $results;

--- a/Planning/PlanningDao.php
+++ b/Planning/PlanningDao.php
@@ -56,10 +56,6 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
     {
         $this->queryBuilder->select('*');
         $this->setWhere($parametres);
-        if (!empty($parametres['limit'])) {
-            $this->queryBuilder->setFirstResult(0);
-            $this->queryBuilder->setMaxResults((int) $parametres['limit']);
-        }
         $res = $this->queryBuilder->execute();
 
         $data = $res->fetchAll(\PDO::FETCH_ASSOC);
@@ -164,21 +160,13 @@ class PlanningDao extends \LibertAPI\Tools\Libraries\ADao
      * Définit les filtres à appliquer à la requête
      *
      * @param array $parametres
-     * @example [filter => [], lt => 23, limit => 4]
+     * @example [filter => []]
      */
     private function setWhere(array $parametres)
     {
         if (!empty($parametres['id'])) {
             $this->queryBuilder->andWhere('planning_id = :id');
             $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
-        }
-        if (!empty($parametres['lt'])) {
-            $this->queryBuilder->andWhere('planning_id < :lt');
-            $this->queryBuilder->setParameter(':lt', (int) $parametres['lt']);
-        }
-        if (!empty($parametres['gt'])) {
-            $this->queryBuilder->andWhere('planning_id > :gt');
-            $this->queryBuilder->setParameter(':gt', (int) $parametres['gt']);
         }
     }
 

--- a/Planning/PlanningRepository.php
+++ b/Planning/PlanningRepository.php
@@ -10,10 +10,10 @@ use LibertAPI\Tools\Libraries\AEntite;
  * @author Wouldsmina
  *
  * @since 0.1
- * @see \Tests\Units\Planning\Repository
+ * @see \LibertAPI\Tests\Units\Planning\PlanningRepository
  *
- * Ne devrait être contacté que par le Planning\Controller
- * Ne devrait contacter que le Planning\Entite, Planning\Dao
+ * Ne devrait être contacté que par le PlanningController
+ * Ne devrait contacter que le PlanningEntite, PlanningDao
  */
 class PlanningRepository extends \LibertAPI\Tools\Libraries\ARepository
 {
@@ -26,25 +26,8 @@ class PlanningRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function getParamsConsumer2Dao(array $paramsConsumer)
     {
-        $filterInt = function ($var) {
-            return filter_var(
-                $var,
-                FILTER_VALIDATE_INT,
-                ['options' => ['min_range' => 1]]
-            );
-        };
-        $results = [];
-        if (!empty($paramsConsumer['limit'])) {
-            $results['limit'] = $filterInt($paramsConsumer['limit']);
-        }
-        if (!empty($paramsConsumer['start-after'])) {
-            $results['lt'] = $filterInt($paramsConsumer['start-after']);
-
-        }
-        if (!empty($paramsConsumer['start-before'])) {
-            $results['gt'] = $filterInt($paramsConsumer['start-before']);
-        }
-        return $results;
+        unset($paramsConsumer);
+        return [];
     }
 
 

--- a/Public/index.php
+++ b/Public/index.php
@@ -25,6 +25,7 @@ $app->get('/hello_world', function(IRequest $request, IResponse $response) {
 
 require_once ROUTE_PATH . 'Absence.php';
 require_once ROUTE_PATH . 'Authentification.php';
+require_once ROUTE_PATH . 'Groupe.php';
 require_once ROUTE_PATH . 'Journal.php';
 require_once ROUTE_PATH . 'Planning.php';
 require_once ROUTE_PATH . 'Utilisateur.php';

--- a/Tests/Units/Absence/Type/TypeEntite.php
+++ b/Tests/Units/Absence/Type/TypeEntite.php
@@ -1,10 +1,8 @@
 <?php
 namespace LibertAPI\Tests\Units\Absence\Type;
 
-use \LibertAPI\Planning\PlanningEntite as _Entite;
-
 /**
- * Classe de test du modèle de planning
+ * Classe de test de l'entité de type d'absence
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina

--- a/Tests/Units/Groupe/GroupeController.php
+++ b/Tests/Units/Groupe/GroupeController.php
@@ -1,0 +1,328 @@
+<?php
+namespace LibertAPI\Tests\Units\Groupe;
+
+/**
+ * Classe de test du contrôleur de groupe
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ */
+final class GroupeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestController
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function initRepository()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->repository = new \mock\LibertAPI\Groupe\GroupeRepository();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initEntite()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->entite = new \LibertAPI\Groupe\GroupeEntite([
+            'id' => 78,
+            'name' => 'Zola',
+            'comment' => 'Baudelaire',
+            'double_validation' => true
+        ]);
+    }
+
+    /**
+     * Teste la méthode get d'une liste avec des droits insuffisants
+     */
+    public function testGetListMissingRight()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $uri = new \mock\Slim\Http\Uri();
+        $this->calling($uri)->getPath = '';
+        $this->calling($this->request)->getQueryParams = [];
+        $this->calling($this->request)->getUri = $uri;
+        $this->calling($this->repository)->getList = function () {
+            throw new \LibertAPI\Tools\Exceptions\MissingRightException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->getList();
+
+        $this->assertFail($response, 403);
+    }
+
+    protected function getOne()
+    {
+        return $this->testedInstance->get($this->request, $this->response, ['groupeId' => 99]);
+    }
+
+    protected function getList()
+    {
+        return $this->testedInstance->get($this->request, $this->response, []);
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * Teste la méthode post d'un json mal formé
+     */
+    public function testPostJsonBadFormat()
+    {
+        // Le framework fait du traitement, un mauvais json est simplement null
+        $this->request->getMockController()->getParsedBody = null;
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+
+        $this->assertFail($response, 400);
+    }
+
+    /**
+     * Teste la méthode post avec un argument de body manquant
+     */
+    public function testPostMissingRequiredArg()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->postOne = function () {
+            throw new \LibertAPI\Tools\Exceptions\MissingArgumentException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+
+        $this->assertFail($response, 412);
+    }
+
+    /**
+     * Teste la méthode post avec un argument de body incohérent
+     */
+    public function testPostBadDomain()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->postOne = function () {
+            throw new \DomainException('Status doit être un int');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+
+        $this->assertFail($response, 412);
+    }
+
+    /**
+     * Teste la méthode post Ok
+     */
+    public function testPostOk()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->router->getMockController()->pathFor = '';
+        $this->repository->getMockController()->postOne = 42;
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(201);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(201)
+            ->string['status']->isIdenticalTo('success')
+            ->array['data']->isNotEmpty()
+        ;
+    }
+
+    /**
+     * Teste le fallback de la méthode post
+     */
+    public function testPostFallback()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->postOne = function () {
+            throw new \Exception('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->post($this->request, $this->response, []);
+
+        $this->assertError($response);
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * Teste la méthode put d'un json mal formé
+     */
+    public function testPutJsonBadFormat()
+    {
+        // Le framework fait du traitement, un mauvais json est simplement null
+        $this->request->getMockController()->getParsedBody = null;
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);
+
+        $this->assertFail($response, 400);
+    }
+
+    /**
+     * Teste la méthode put avec un détail non trouvé (id en Bad domaine)
+     */
+    public function testPutNotFound()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = function () {
+            throw new \DomainException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);
+
+        $this->boolean($response->isNotFound())->isTrue();
+    }
+
+    /**
+     * Teste le fallback de la méthode getOne du put
+     */
+    public function testPutGetOneFallback()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = function () {
+            throw new \LogicException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);
+        $this->assertError($response);
+    }
+
+    /**
+     * Teste la méthode put avec un argument de body manquant
+     */
+    public function testPutMissingRequiredArg()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = $this->entite;
+
+        $this->repository->getMockController()->putOne = function () {
+            throw new \LibertAPI\Tools\Exceptions\MissingArgumentException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);
+
+        $this->assertFail($response, 412);
+    }
+
+    /**
+     * Teste la méthode put avec un argument de body incohérent
+     */
+    public function testPutBadDomain()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = $this->entite;
+        $this->repository->getMockController()->putOne = function () {
+            throw new \DomainException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);
+
+        $this->assertFail($response, 412);
+    }
+
+    /**
+     * Teste le fallback de la méthode putOne du put
+     */
+    public function testPutPutOneFallback()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = $this->entite;
+        $this->repository->getMockController()->putOne = function () {
+            throw new \LogicException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);
+        $this->assertError($response);
+    }
+
+    /**
+     * Teste la méthode put Ok
+     */
+    public function testPutOk()
+    {
+        $this->request->getMockController()->getParsedBody = [];
+        $this->repository->getMockController()->getOne = $this->entite;
+        $this->repository->getMockController()->putOne = '';
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);
+
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(204);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(204)
+            ->string['status']->isIdenticalTo('success')
+            ->string['data']->isIdenticalTo('')
+        ;
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * Teste la méthode delete avec un détail non trouvé (id en Bad domaine)
+     */
+    public function testDeleteNotFound()
+    {
+        $this->repository->getMockController()->getOne = function () {
+            throw new \DomainException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->delete($this->request, $this->response, ['groupeId' => 99]);
+
+        $this->boolean($response->isNotFound())->isTrue();
+    }
+
+    /**
+     * Teste le fallback de la méthode delete
+     */
+    public function testDeleteFallback()
+    {
+        $this->repository->getMockController()->getOne = function () {
+            throw new \LogicException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->delete($this->request, $this->response, ['groupeId' => 99]);
+        $this->assertError($response);
+    }
+
+    /**
+     * Teste la méthode delete Ok
+     */
+    public function testDeleteOk()
+    {
+        $this->repository->getMockController()->getOne = $this->entite;
+        $this->repository->getMockController()->deleteOne = '';
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+
+        $response = $this->testedInstance->delete($this->request, $this->response, ['groupeId' => 99]);
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(200);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(200)
+            ->string['status']->isIdenticalTo('success')
+            ->array['data']->isNotEmpty()
+        ;
+    }
+}

--- a/Tests/Units/Groupe/GroupeDao.php
+++ b/Tests/Units/Groupe/GroupeDao.php
@@ -1,0 +1,65 @@
+<?php
+namespace LibertAPI\Tests\Units\Groupe;
+
+use LibertAPI\Groupe\GroupeEntite;
+
+/**
+ * Classe de test du DAO de groupe
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ */
+final class GroupeDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
+{
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * Teste la méthode post quand tout est ok
+     */
+    public function testPostOk()
+    {
+        $this->calling($this->connector)->lastInsertId = 314;
+        $this->newTestedInstance($this->connector);
+
+        $postId = $this->testedInstance->post(new GroupeEntite($this->entiteContent));
+
+        $this->integer($postId)->isIdenticalTo(314);
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * Teste la méthode put quand tout est ok
+     */
+    public function testPutOk()
+    {
+        $this->newTestedInstance($this->connector);
+
+        $put = $this->testedInstance->put(new GroupeEntite($this->entiteContent));
+
+        $this->variable($put)->isNull();
+    }
+
+    protected function getStorageContent()
+    {
+        return [
+            'g_gid' => 42,
+            'g_groupename' => 'name',
+            'g_comment' => 'this is a storage comment',
+            'g_double_valid' => 'Y'
+        ];
+    }
+
+    private $entiteContent = [
+        'id' => 72,
+        'name' => 'name',
+        'comment' => 'text',
+        'double_validation' => true,
+    ];
+}

--- a/Tests/Units/Groupe/GroupeEntite.php
+++ b/Tests/Units/Groupe/GroupeEntite.php
@@ -1,0 +1,77 @@
+<?php
+namespace LibertAPI\Tests\Units\Groupe;
+
+/**
+ * Classe de test de l'entité de groupe
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ */
+final class GroupeEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEntite
+{
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithId()
+    {
+        $id = 3;
+        $comment = 'this is a comment';
+
+        $this->newTestedInstance(['id' => $id, 'name' => 'name', 'comment' => $comment, 'double_validation' => true]);
+
+        $this->assertConstructWithId($this->testedInstance, $id);
+        $this->string($this->testedInstance->getName())->isIdenticalTo('name');
+        $this->string($this->testedInstance->getComment())->isIdenticalTo($comment);
+        $this->boolean($this->testedInstance->isDoubleValidated())->isTrue();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithoutId()
+    {
+        $this->newTestedInstance(['comment' => 'a', 'double_validation' => true]);
+
+        $this->variable($this->testedInstance->getId())->isNull();
+    }
+
+    /**
+     * Teste la méthode populate avec un mauvais domaine de définition
+     */
+    public function testPopulateBadDomain()
+    {
+        $this->newTestedInstance([]);
+        $data = ['name' => 'name', 'comment' => '', 'double_validation' => 'N'];
+
+        $this->exception(function () use ($data) {
+            $this->testedInstance->populate($data);
+        })->isInstanceOf('\DomainException');
+    }
+
+    /**
+     * Teste la méthode populate avec ok
+     */
+    public function testPopulateOk()
+    {
+        $this->newTestedInstance([]);
+        $data = ['name' => 'name', 'comment' => 'k', 'double_validation' => 'N'];
+
+        $this->testedInstance->populate($data);
+
+        $this->string($this->testedInstance->getName())->isIdenticalTo('name');
+        $this->string($this->testedInstance->getComment())->isIdenticalTo('k');
+        $this->boolean($this->testedInstance->isDoubleValidated())->isFalse();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testReset()
+    {
+        $this->newTestedInstance(['name' => 'name', 'comment' => 'k', 'double_validation' => 'N']);
+
+        $this->assertReset($this->testedInstance);
+    }
+}

--- a/Tests/Units/Groupe/GroupeRepository.php
+++ b/Tests/Units/Groupe/GroupeRepository.php
@@ -1,0 +1,66 @@
+<?php
+namespace LibertAPI\Tests\Units\Groupe;
+
+/**
+ * Classe de test du repository de groupe
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ */
+final class GroupeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
+{
+    protected function initDao()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $this->dao = new \mock\LibertAPI\Groupe\GroupeDao();
+    }
+
+    protected function initEntite()
+    {
+        $this->entite = new \LibertAPI\Groupe\GroupeEntite([]);
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * Teste le fallback de la méthode deleteOne
+     */
+    public function testDeleteFallback()
+    {
+        $this->dao->getMockController()->delete = function () {
+            throw new \LogicException('');
+        };
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->deleteOne($this->entite);
+        })->isInstanceOf('\LogicException');
+
+    }
+
+    /**
+     * Teste la méthode deleteOne tout ok
+     */
+    public function testDeleteOk()
+    {
+        $this->dao->getMockController()->delete = 4;
+        $this->newTestedInstance($this->dao);
+
+        $this->variable($this->testedInstance->deleteOne($this->entite))->isNull();
+    }
+
+    protected function getEntiteContent()
+    {
+        return [
+            'id' => 72,
+            'name' => 'name',
+            'comment' => 'text',
+            'double_validation' => true,
+        ];
+    }
+}

--- a/Tests/Units/Tools/Libraries/ARestController.php
+++ b/Tests/Units/Tools/Libraries/ARestController.php
@@ -24,13 +24,19 @@ abstract class ARestController extends AController
     protected $currentEmploye;
 
     /**
+     * @var UtilisateurEntite Standardisation d'un rôle admin
+     */
+    protected $currentAdmin;
+
+    /**
      * Init des tests
      */
     public function beforeTestMethod($method)
     {
         parent::beforeTestMethod($method);
-        $this->currentEmploye = new UtilisateurEntite(['id' => 'user', 'isResp' => false]);
-        $this->currentResponsable = new UtilisateurEntite(['id' => 'resp', 'isResp' => true]);
+        $this->currentEmploye = new UtilisateurEntite(['id' => 'user', 'isResp' => false, 'isHr' => false, 'isAdmin' => false]);
+        $this->currentResponsable = new UtilisateurEntite(['id' => 'resp', 'isResp' => true, 'isHr' => false, 'isAdmin' => false]);
+        $this->currentAdmin = new UtilisateurEntite(['id' => 'admin', 'isResp' => true, 'isHr' => false, 'isAdmin' => true]);
     }
 
     /*************************************************
@@ -96,7 +102,7 @@ abstract class ARestController extends AController
         $this->repository->getMockController()->getList = [
             42 => $this->entite,
         ];
-        $this->newTestedInstance($this->repository, $this->router, $this->currentResponsable);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
 
         $response = $this->getList();
         $data = $this->getJsonDecoded($response->getBody());
@@ -119,7 +125,7 @@ abstract class ARestController extends AController
         $this->repository->getMockController()->getList = function () {
             throw new \UnexpectedValueException('');
         };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentResponsable);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
 
         $response = $this->getList();
 
@@ -135,7 +141,7 @@ abstract class ARestController extends AController
         $this->repository->getMockController()->getList = function () {
             throw new \Exception('');
         };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentResponsable);
+        $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
 
         $response = $this->getList();
         $this->assertError($response);

--- a/Tools/Libraries/ADao.php
+++ b/Tools/Libraries/ADao.php
@@ -61,7 +61,7 @@ abstract class ADao
      * Retourne une liste de ressource correspondant à des critères
      *
      * @param array $parametres
-     * @example [filter => [], lt => 23, limit => 4]
+     * @example [filter => []]
      *
      * @return array, vide si les critères ne sont pas pertinents
      */

--- a/Tools/Libraries/ARepository.php
+++ b/Tools/Libraries/ARepository.php
@@ -46,7 +46,6 @@ abstract class ARepository
      * Retourne une liste de ressource correspondant à des critères
      *
      * @param array $parametres
-     * @example [offset => 4, start-after => 23, filter => 'name::chapo|status::1,3']
      *
      * @return array [$objetId => $objet]
      */
@@ -62,7 +61,6 @@ abstract class ARepository
      * Essentiel pour séparer / traduire les contextes Client / DAO
      *
      * @param array $paramsConsumer Paramètres reçus
-     * @example [offset => 4, start-after => 23, filter => 'name::chapo|status::1,3']
      *
      * @return array
      */

--- a/Tools/Route/Groupe.php
+++ b/Tools/Route/Groupe.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Doit être importé après la création de $app. Ne créé rien.
+ *
+ * La convention de nommage est de mettre les routes au singulier
+ */
+
+/* Routes sur le groupe */
+$app->group('/groupe', function () {
+    $this->group('/{groupeId:[0-9]+}', function () {
+        /* Detail */
+        $this->get('', 'controller:get')->setName('getGroupeDetail');
+    });
+
+    /* Collection */
+    $this->get('', 'controller:get')->setName('getGroupeListe');
+});

--- a/Utilisateur/UtilisateurController.php
+++ b/Utilisateur/UtilisateurController.php
@@ -59,7 +59,6 @@ final class UtilisateurController extends \LibertAPI\Tools\Libraries\AController
      * @param int $id ID de l'élément
      *
      * @return IResponse, 404 si l'élément n'est pas trouvé, 200 sinon
-     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
      */
     private function getOne(IResponse $response, $id)
     {


### PR DESCRIPTION
Ajout d'une route liée à l'admin, celle des groupes. Cette route ne présente que les informations de l'identité d'un groupe, ça ne montre pas les associations. En effet, je me donne pour limite à chaque fois 1KLOC (ce qui donne 2 à 4 heures de review) et ajouter les associations aurait fait trop.

J'ai par contre déjà posé la base de ce que devront être les routes d'associations à l'avenir : 
    - les responsables : groupe/N/premier_validateur (avec changement de nom pour ne pas confondre avec le rôle, ce n'est pas la même chose)
    - les employes : groupe/N/employes
    - les grand responsables : groupe/N/second_validateur

J'ai profité que j'étais là pour enlever un truc qui ne nous sert pas pour le moment, ni dans l'API, ni dans la partie web : les prédicats de filtres. Si vraiment on en a besoin on les remettra, mais en attendant c'est du code inutile qui ne vit pas.