### PR TITLE
Ajout de la route pour les responsables de groupe

### DIFF
--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -84,10 +84,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($responseResources as $responseResource) {
-            $entites[] = $this->buildData($responseResource);
-        }
+        $entites = array_map([$this, 'buildData'], $responseResources);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }

--- a/Absence/Type/TypeDao.php
+++ b/Absence/Type/TypeDao.php
@@ -61,11 +61,11 @@ class TypeDao extends \LibertAPI\Tools\Libraries\ADao
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new TypeEntite($this->getStorage2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
+        $entites = array_map(function ($value) {
+                return new TypeEntite($this->getStorage2Entite($value));
+            },
+            $data
+        );
 
         return $entites;
     }

--- a/Groupe/GroupeController.php
+++ b/Groupe/GroupeController.php
@@ -91,10 +91,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($groupes as $groupe) {
-            $entites[] = $this->buildData($groupe);
-        }
+        $entites = array_map([$this, 'buildData'], $groupes);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }

--- a/Groupe/GroupeDao.php
+++ b/Groupe/GroupeDao.php
@@ -64,11 +64,11 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new GroupeEntite($this->getStorage2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
+        $entites = array_map(function ($value) {
+                return new GroupeEntite($this->getStorage2Entite($value));
+            },
+            $data
+        );
 
         return $entites;
     }

--- a/Groupe/GroupeEntite.php
+++ b/Groupe/GroupeEntite.php
@@ -12,7 +12,7 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
  * @since 0.7
  * @see \LibertAPI\Tests\Units\Groupe\GroupeEntite
  *
- * Ne devrait être contacté que par le GroupeRepository
+ * Ne devrait être contacté que par le GroupeDao
  * Ne devrait contacter personne
  */
 class GroupeEntite extends \LibertAPI\Tools\Libraries\AEntite

--- a/Groupe/Responsable/ResponsableController.php
+++ b/Groupe/Responsable/ResponsableController.php
@@ -74,7 +74,6 @@ implements Interfaces\IGetable
             'isAdmin' => $entite->isAdmin(),
             'isHr' => $entite->isHautReponsable(),
             'isActif' => $entite->isActif(),
-            'seeAll' => $entite->canSeeAll(),
             'password' => $entite->getMotDePasse(),
             'quotite' => $entite->getQuotite(),
             'email' => $entite->getMail(),

--- a/Groupe/Responsable/ResponsableController.php
+++ b/Groupe/Responsable/ResponsableController.php
@@ -1,0 +1,88 @@
+<?php
+namespace LibertAPI\Groupe\Responsable;
+
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+use LibertAPI\Tools\Interfaces;
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+use LibertAPI\Utilisateur\UtilisateurEntite;
+
+/**
+ * Contrôleur de responsable de groupes
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ * @see \Tests\Units\GroupeController
+ *
+ * Ne devrait être contacté que par le routeur
+ * Ne devrait contacter que le ResponsableRepository
+ */
+final class ResponsableController extends \LibertAPI\Tools\Libraries\AController
+implements Interfaces\IGetable
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function ensureAccessUser($order, UtilisateurEntite $utilisateur)
+    {
+        unset($order);
+        if (!$utilisateur->isAdmin()) {
+            throw new \LibertAPI\Tools\Exceptions\MissingRightException('');
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get(IRequest $request, IResponse $response, array $arguments)
+    {
+        unset($arguments);
+        try {
+            $this->ensureAccessUser(__FUNCTION__, $this->currentUser);
+            $groupes = $this->repository->getList(
+                $request->getQueryParams()
+            );
+        } catch (\UnexpectedValueException $e) {
+            return $this->getResponseNoContent($response);
+        } catch (\LibertAPI\Tools\Exceptions\MissingRightException $e) {
+            return $this->getResponseForbidden($response, $request);
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+        $entites = array_map([$this, 'buildData'], $groupes);
+
+        return $this->getResponseSuccess($response, $entites, 200);
+    }
+
+    /**
+     * Construit le « data » du json
+     *
+     * @param UtilisateurEntite $entite Responsable
+     *
+     * @return array
+     */
+    private function buildData(UtilisateurEntite $entite)
+    {
+        return [
+            'id' => $entite->getId(),
+            'login' => $entite->getLogin(),
+            'nom' => $entite->getNom(),
+            'prenom' => $entite->getPrenom(),
+            'isResp' => $entite->isResponsable(),
+            'isAdmin' => $entite->isAdmin(),
+            'isHr' => $entite->isHautReponsable(),
+            'isActif' => $entite->isActif(),
+            'seeAll' => $entite->canSeeAll(),
+            'password' => $entite->getMotDePasse(),
+            'quotite' => $entite->getQuotite(),
+            'email' => $entite->getMail(),
+            'numeroExercice' => $entite->getNumeroExercice(),
+            'planningId' => $entite->getPlanningId(),
+            'heureSolde' => $entite->getHeureSolde(),
+            'dateInscription' => $entite->getDateInscription(),
+            'dateLastAccess' => $entite->getDateLastAccess(),
+        ];
+    }
+}

--- a/Groupe/Responsable/ResponsableDao.php
+++ b/Groupe/Responsable/ResponsableDao.php
@@ -1,0 +1,150 @@
+<?php
+namespace LibertAPI\Groupe\Responsable;
+
+use LibertAPI\Tools\Libraries\AEntite;
+use LibertAPI\Utilisateur\UtilisateurEntite;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ *
+ * Ne devrait être contacté que par ResponsableRepository
+ * Ne devrait contacter personne
+ */
+class ResponsableDao extends \LibertAPI\Tools\Libraries\ADao
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function getById($id)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getList(array $parametres)
+    {
+        $this->queryBuilder->select('users.*, users.u_login AS id');
+        $this->queryBuilder->join('current', 'conges_users', 'users');
+        $this->setWhere($parametres);
+        $res = $this->queryBuilder->execute();
+
+        $data = $res->fetchAll(\PDO::FETCH_ASSOC);
+        if (empty($data)) {
+            throw new \UnexpectedValueException('No resource match with these parameters');
+        }
+
+        $entites = [];
+        foreach ($data as $value) {
+            $entite = new UtilisateurEntite($this->getStorage2Entite($value));
+            $entites[$entite->getId()] = $entite;
+        }
+
+        return $entites;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Duplication de la fonction dans UtilisateurDao (Cf. decisions.md #2018-02-17)
+     */
+    final protected function getStorage2Entite(array $dataDao)
+    {
+        return [
+            'id' => $dataDao['id'],
+            'login' => $dataDao['u_login'],
+            'nom' => $dataDao['u_nom'],
+            'prenom' => $dataDao['u_prenom'],
+            'isResp' => $dataDao['u_is_resp'] === 'Y',
+            'isAdmin' => $dataDao['u_is_admin'] === 'Y',
+            'isHr' => $dataDao['u_is_hr'] === 'Y',
+            'isActive' => $dataDao['u_is_active'] === 'Y',
+            'seeAll' => $dataDao['u_see_all'] === 'Y',
+            'password' => $dataDao['u_passwd'],
+            'quotite' => $dataDao['u_quotite'],
+            'email' => $dataDao['u_email'],
+            'numeroExercice' => $dataDao['u_num_exercice'],
+            'planningId' => $dataDao['planning_id'],
+            'heureSolde' => $dataDao['u_heure_solde'],
+            'dateInscription' => $dataDao['date_inscription'],
+            'token' => $dataDao['token'],
+            'dateLastAccess' => $dataDao['date_last_access'],
+        ];
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function post(AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function put(AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getEntite2Storage(AEntite $entite)
+    {
+        return [];
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function delete($id)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /**
+     * Définit les filtres à appliquer à la requête
+     *
+     * @param array $parametres
+     * @example [filter => []]
+     */
+    private function setWhere(array $parametres)
+    {
+        if (!empty($parametres['id'])) {
+            $this->queryBuilder->andWhere('g_gid = :id');
+            $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getTableName()
+    {
+        return 'conges_groupe_resp';
+    }
+}

--- a/Groupe/Responsable/ResponsableDao.php
+++ b/Groupe/Responsable/ResponsableDao.php
@@ -35,7 +35,7 @@ class ResponsableDao extends \LibertAPI\Tools\Libraries\ADao
     public function getList(array $parametres)
     {
         $this->queryBuilder->select('users.*, users.u_login AS id');
-        $this->queryBuilder->join('current', 'conges_users', 'users');
+        $this->queryBuilder->innerJoin('current', 'conges_users', 'users', 'current.gr_login = u_login');
         $this->setWhere($parametres);
         $res = $this->queryBuilder->execute();
 
@@ -44,11 +44,9 @@ class ResponsableDao extends \LibertAPI\Tools\Libraries\ADao
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new UtilisateurEntite($this->getStorage2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
+        $entites = array_map(function ($value) {
+            return new UtilisateurEntite($this->getStorage2Entite($value));
+        }, $data);
 
         return $entites;
     }

--- a/Groupe/Responsable/ResponsableRepository.php
+++ b/Groupe/Responsable/ResponsableRepository.php
@@ -1,0 +1,73 @@
+<?php
+namespace LibertAPI\Groupe\Responsable;
+
+use LibertAPI\Tools\Libraries\AEntite;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ * @see \LibertAPI\Tests\Units\Groupe\ResponsableRepository
+ */
+class ResponsableRepository extends \LibertAPI\Tools\Libraries\ARepository
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function getOne($id)
+    {
+        throw new \RuntimeException('#' . $id . ' is not a callable resource');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getParamsConsumer2Dao(array $paramsConsumer)
+    {
+        unset($paramsConsumer);
+        return [];
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function postOne(array $data, AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function putOne(array $data, AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteOne(AEntite $entite)
+    {
+        throw new \RuntimeException('Action is forbidden');
+    }
+}

--- a/Journal/JournalController.php
+++ b/Journal/JournalController.php
@@ -34,7 +34,6 @@ final class JournalController extends \LibertAPI\Tools\Libraries\AController
      * @param array $arguments Arguments de route
      *
      * @return IResponse
-     * @throws \Exception en cas d'erreur inconnue (fallback, ne doit pas arriver)
      */
     public function get(IRequest $request, IResponse $response, array $arguments)
     {
@@ -46,13 +45,9 @@ final class JournalController extends \LibertAPI\Tools\Libraries\AController
         } catch (\UnexpectedValueException $e) {
             return $this->getResponseNoContent($response);
         } catch (\Exception $e) {
-            throw $e;
+            return $this->getResponseError($response, $e);
         }
-
-        $entites = [];
-        foreach ($resources as $resource) {
-            $entites[] = $this->buildData($resource);
-        }
+        $entites = array_map([$this, 'buildData'], $resources);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }

--- a/Journal/JournalDao.php
+++ b/Journal/JournalDao.php
@@ -39,11 +39,9 @@ class JournalDao extends \LibertAPI\Tools\Libraries\ADao
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new JournalEntite($this->getStorage2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
+        $entites = array_map(function ($value) {
+            return new JournalEntite($this->getStorage2Entite($value));
+        }, $data);
 
         return $entites;
     }

--- a/Planning/Creneau/CreneauController.php
+++ b/Planning/Creneau/CreneauController.php
@@ -85,10 +85,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($creneaux as $creneau) {
-            $entites[] = $this->buildData($creneau);
-        }
+        $entites = array_map([$this, 'buildData'], $creneaux);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }

--- a/Planning/Creneau/CreneauEntite.php
+++ b/Planning/Creneau/CreneauEntite.php
@@ -12,7 +12,7 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
  * @since 0.1
  * @see \LibertAPI\Tests\Units\Planning\Creneau\Entite
  *
- * Ne devrait être contacté que par le Planning\Creneau\Repository
+ * Ne devrait être contacté que par le Planning\Creneau\CreneauDao
  * Ne devrait contacter personne
  */
 class CreneauEntite extends \LibertAPI\Tools\Libraries\AEntite

--- a/Planning/PlanningController.php
+++ b/Planning/PlanningController.php
@@ -94,10 +94,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($plannings as $planning) {
-            $entites[] = $this->buildData($planning);
-        }
+        $entites = array_map([$this, 'buildData'], $plannings);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }

--- a/Planning/PlanningEntite.php
+++ b/Planning/PlanningEntite.php
@@ -12,7 +12,7 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
  * @since 0.1
  * @see \LibertAPI\Tests\Units\Planning\PlanningEntite
  *
- * Ne devrait être contacté que par le Planning\Repository
+ * Ne devrait être contacté que par le Planning\PlanningDao
  * Ne devrait contacter personne
  */
 class PlanningEntite extends \LibertAPI\Tools\Libraries\AEntite

--- a/Tests/Units/Groupe/Responsable/ResponsableController.php
+++ b/Tests/Units/Groupe/Responsable/ResponsableController.php
@@ -1,0 +1,121 @@
+<?php
+namespace LibertAPI\Tests\Units\Groupe\Responsable;
+
+use LibertAPI\Utilisateur\UtilisateurEntite;
+
+/**
+ * Classe de test du contrôleur de reponsable de groupe
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ */
+final class ResponsableController extends \LibertAPI\Tests\Units\Tools\Libraries\AController
+{
+    /**
+     * @var UtilisateurEntite Standardisation d'un rôle admin
+     */
+    protected $currentAdmin;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function beforeTestMethod($method)
+    {
+        parent::beforeTestMethod($method);
+        $this->currentAdmin = new UtilisateurEntite(['id' => 'user', 'isAdmin' => true]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initRepository()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $this->repository = new \mock\LibertAPI\Groupe\Responsable\ResponsableRepository();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initEntite()
+    {
+        $this->entite = new \LibertAPI\Utilisateur\UtilisateurEntite([
+            'id' => 816,
+            'login' => 'Spider-man',
+            'nom' => 'Parker',
+            'prenom' => 'Peter',
+            'isResp' => 'N',
+            'isAdmin' => 'N',
+            'isHr' => 'N',
+            'isActif' => 'Y',
+            'seeAll' => 'N',
+            'password' => 'MJ',
+            'quotite' => '10',
+            'email' => 'p.parker@dailybugle.com',
+            'numeroExercice' => 3,
+            'planningId' => 666,
+            'heureSolde' => 1,
+            'dateInscription' => '1-08-1962',
+            'token' => '',
+            'dateLastAccess' => '1-08-2006',
+        ]);
+    }
+
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * Teste la méthode get d'une liste trouvée
+     */
+    public function testGetFound()
+    {
+        $this->calling($this->request)->getQueryParams = [];
+        $this->calling($this->repository)->getList = [$this->entite,];
+        $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
+        $response = $this->testedInstance->get($this->request, $this->response, []);
+        $data = $this->getJsonDecoded($response->getBody());
+
+        $this->integer($response->getStatusCode())->isIdenticalTo(200);
+        $this->array($data)
+            ->integer['code']->isIdenticalTo(200)
+            ->string['status']->isIdenticalTo('success')
+            ->string['message']->isIdenticalTo('OK')
+            //->array['data']->hasSize(1) // TODO: l'asserter atoum en sucre syntaxique est buggé, faire un ticket
+        ;
+        $this->array($data['data'][0])->hasKey('id');
+    }
+
+    /**
+     * Teste la méthode get d'une liste non trouvée
+     */
+    public function testGetNotFound()
+    {
+        $this->calling($this->request)->getQueryParams = [];
+        $this->calling($this->repository)->getList = function () {
+            throw new \UnexpectedValueException('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
+        $response = $this->testedInstance->get($this->request, $this->response, []);
+
+        $this->assertSuccessEmpty($response);
+    }
+
+    /**
+     * Teste le fallback de la méthode get d'une liste
+     */
+    public function testGetFallback()
+    {
+        $this->calling($this->request)->getQueryParams = [];
+        $this->calling($this->repository)->getList = function () {
+            throw new \Exception('');
+        };
+        $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
+
+        $response = $this->testedInstance->get($this->request, $this->response, []);
+        $this->assertError($response);
+    }
+}

--- a/Tests/Units/Groupe/Responsable/ResponsableDao.php
+++ b/Tests/Units/Groupe/Responsable/ResponsableDao.php
@@ -1,17 +1,17 @@
 <?php
-namespace LibertAPI\Tests\Units\Journal;
+namespace LibertAPI\Tests\Units\Groupe\Responsable;
 
-use LibertAPI\Journal\JournalEntite;
+use LibertAPI\Utilisateur\UtilisateurEntite;
 
 /**
- * Classe de test du DAO de planning
+ * Classe de test du DAO de responsable de groupe
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.5
+ * @since 0.7
  */
-final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
+final class ResponsableDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
 {
     /*************************************************
      * GET
@@ -49,7 +49,7 @@ final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->post(new JournalEntite([]));
+            $this->testedInstance->post(new UtilisateurEntite([]));
         })->isInstanceOf(\RuntimeException::class);
     }
 
@@ -65,7 +65,7 @@ final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->put(new JournalEntite([]));
+            $this->testedInstance->put(new UtilisateurEntite([]));
         })->isInstanceOf(\RuntimeException::class);
     }
 
@@ -85,16 +85,30 @@ final class JournalDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
         })->isInstanceOf(\RuntimeException::class);
     }
 
+    /**
+     * Duplication de la fonction dans UtilisateurDao (Cf. decisions.md #2018-02-17)
+     */
     protected function getStorageContent()
     {
         return [
-            'log_id' => 81,
-            'log_p_num' => 1213,
-            'log_user_login_par' => 'Baloo',
-            'log_user_login_pour' => 'Mowgli',
-            'log_etat' => 'gere',
-            'log_comment' => 'nope',
-            'log_date' => '2017-12-01',
+            'id' => 'Aladdin',
+            'token' => 'token',
+            'date_last_access' => 'date_last_access',
+            'u_login' => 'Aladdin',
+            'u_prenom' => 'Aladdin',
+            'u_nom' => 'Genie',
+            'u_is_resp' => 'Y',
+            'u_is_admin' => 'Y',
+            'u_is_hr' => 'N',
+            'u_is_active' => 'Y',
+            'u_see_all' => 'Y',
+            'u_passwd' => 'Sésame Ouvre toi',
+            'u_quotite' => '21220',
+            'u_email' => 'aladdin@example.org',
+            'u_num_exercice' => '3',
+            'planning_id' => 12,
+            'u_heure_solde' => 1,
+            'date_inscription' => 123456789,
         ];
     }
 }

--- a/Tests/Units/Groupe/Responsable/ResponsableRepository.php
+++ b/Tests/Units/Groupe/Responsable/ResponsableRepository.php
@@ -1,0 +1,100 @@
+<?php
+namespace LibertAPI\Tests\Units\Groupe\Responsable;
+
+/**
+ * Classe de test du repository de responsable de groupe
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.5
+ */
+final class ResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
+{
+    protected function initDao()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $this->dao = new \mock\LibertAPI\Groupe\Responsable\ResponsableDao();
+    }
+
+    protected function initEntite()
+    {
+        $this->entite = new \LibertAPI\Utilisateur\UtilisateurEntite([]);
+    }
+
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * Teste la méthode getOne
+     */
+    public function testGetOne()
+    {
+        $this->calling($this->dao)->getById = [];
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->getOne(99);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * Teste la méthode postOne
+     */
+    public function testPostOne()
+    {
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->postOne([], $this->entite);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * Teste la méthode putOne
+     */
+    public function testPutOne()
+    {
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->putOne([], $this->entite);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * Teste la méthode deleteOne
+     */
+    public function testDeleteOne()
+    {
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->deleteOne($this->entite);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getEntiteContent()
+    {
+        return [
+        ];
+    }
+}

--- a/Tests/Units/Journal/JournalController.php
+++ b/Tests/Units/Journal/JournalController.php
@@ -63,9 +63,7 @@ final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\ACo
     public function testGetFound()
     {
         $this->calling($this->request)->getQueryParams = [];
-        $this->calling($this->repository)->getList = [
-            42 => $this->entite,
-        ];
+        $this->calling($this->repository)->getList = [$this->entite,];
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->get($this->request, $this->response, []);
         $data = $this->getJsonDecoded($response->getBody());
@@ -106,8 +104,7 @@ final class JournalController extends \LibertAPI\Tests\Units\Tools\Libraries\ACo
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
-        $this->exception(function () {
-            $this->testedInstance->get($this->request, $this->response, []);
-        })->isInstanceOf('\Exception');
+        $response = $this->testedInstance->get($this->request, $this->response, []);
+        $this->assertError($response);
     }
 }

--- a/Tests/Units/Planning/PlanningController.php
+++ b/Tests/Units/Planning/PlanningController.php
@@ -32,6 +32,10 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
         $this->entite->getMockController()->getStatus = 12;
     }
 
+    /*************************************************
+     * GET
+     *************************************************/
+
     /**
      * Teste la méthode get d'une liste avec des droits insuffisants
      */

--- a/Tests/Units/Tools/Libraries/ARestController.php
+++ b/Tests/Units/Tools/Libraries/ARestController.php
@@ -99,9 +99,7 @@ abstract class ARestController extends AController
     public function testGetListFound()
     {
         $this->request->getMockController()->getQueryParams = [];
-        $this->repository->getMockController()->getList = [
-            42 => $this->entite,
-        ];
+        $this->repository->getMockController()->getList = [$this->entite,];
         $this->newTestedInstance($this->repository, $this->router, $this->currentAdmin);
 
         $response = $this->getList();

--- a/Tools/Libraries/ADao.php
+++ b/Tools/Libraries/ADao.php
@@ -21,7 +21,7 @@ abstract class ADao
     {
         $this->storageConnector = $storageConnector;
         $this->queryBuilder = $storageConnector->createQueryBuilder();
-        $this->queryBuilder->from($this->getTableName());
+        $this->queryBuilder->from($this->getTableName(), 'current');
     }
 
     /**

--- a/Tools/Route/Groupe.php
+++ b/Tools/Route/Groupe.php
@@ -10,6 +10,9 @@ $app->group('/groupe', function () {
     $this->group('/{groupeId:[0-9]+}', function () {
         /* Detail */
         $this->get('', 'controller:get')->setName('getGroupeDetail');
+
+        /* Dependances de groupe : responsable */
+        $this->get('/responsable', 'controller:get')->setName('getGroupeResponsableListe');
     });
 
     /* Collection */

--- a/Utilisateur/UtilisateurController.php
+++ b/Utilisateur/UtilisateurController.php
@@ -97,10 +97,7 @@ final class UtilisateurController extends \LibertAPI\Tools\Libraries\AController
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);
         }
-        $entites = [];
-        foreach ($utilisateurs as $utilisateur) {
-            $entites[] = $this->buildData($utilisateur);
-        }
+        $entites = array_map([$this, 'buildData'], $utilisateurs);
 
         return $this->getResponseSuccess($response, $entites, 200);
     }

--- a/Utilisateur/UtilisateurDao.php
+++ b/Utilisateur/UtilisateurDao.php
@@ -58,11 +58,9 @@ class UtilisateurDao extends \LibertAPI\Tools\Libraries\ADao
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $entites = [];
-        foreach ($data as $value) {
-            $entite = new UtilisateurEntite($this->getStorage2Entite($value));
-            $entites[$entite->getId()] = $entite;
-        }
+        $entites = array_map(function ($value) {
+            return new UtilisateurEntite($this->getStorage2Entite($value));
+        }, $data);
 
         return $entites;
     }

--- a/Utilisateur/UtilisateurEntite.php
+++ b/Utilisateur/UtilisateurEntite.php
@@ -14,7 +14,7 @@ use LibertAPI\Tools\Helpers\Formatter;
  * @since 0.2
  * @see \LibertAPI\Tests\Units\Utilisateur\Entite
  *
- * Ne devrait être contacté que par le Utilisateur\Repository
+ * Ne devrait être contacté que par le Utilisateur\UtilisateurDao et Groupe\Responsable\ResponsableDao
  * Ne devrait contacter personne
  */
 class UtilisateurEntite extends \LibertAPI\Tools\Libraries\AEntite

--- a/decisions.md
+++ b/decisions.md
@@ -1,3 +1,8 @@
+## 2018-02-17
+* Dans le processus d'écriture de routes pour l'API, la table `conges_groupe_resp` fait apparaître une relation N-N ; problème, rien est encore fait dans ce sens et le [« package par feature »](http://www.codingthearchitecture.com/2015/03/08/package_by_component_and_architecturally_aligned_testing.html) nous ennuie un peu. Suivant la règle de 3 et le principe selon lequel on doit repousser les décisions importantes plus tard, je vise la simplicité et manipule l'entité « Utilisateur/UtilisateurEntite » suite à la requête. Quand nous en saurons plus on changera.
+
+~ Prytoegrian
+
 ## 2017-11-04
 * À l'origine, j'avais mis les routes au pluriel car la sémantique était meilleure (avec `GET /plannings`, je veux la liste des plannings), mais l'idée atteint ses limites quand on se confronte à la langue (ex : journaux). Obliger à tenir une map serait inutilement lourd, aussi je vais au plus simple et je mets toutes les routes au singulier.
 
@@ -20,7 +25,7 @@
 
 * Histoire de faciliter la transmission des connaissances et des intentions, j'amorce la création de ce fichier, en m'appuyant sur cette [proposition](http://akazlou.com/posts/2015-11-09-every-project-should-have-decisions.html).
 
-* Convaincu de la nécessité de séparer les reponsabilités de l'application malgré une apparence de simplicité, je commence la création d'une API.
+* Convaincu de la nécessité de séparer les responsabilités de l'application malgré une apparence de simplicité, je commence la création d'une API.
 L'un des risques qu'il pourrait y avoir est la dispersion et un ralentissement dans le processus de production,
 puisqu'il faut qu'un projet soit à jour pour que l'autre puisse avancer.
 Je suppose que ça ne sera vrai que le temps que l'API gagne en puissance.


### PR DESCRIPTION
On avance, petit à petit. Cette PR, en plus de faire son job, pose les bases pour l'ajout quasi instantanée de `groupe_haut_responsable` et `groupe_employe`.

Comme la table derrière cette route est une relation `N-N`, il n'y aucun intérêt de rechercher par id d'entité, il n'y a donc pas de route `GET /groupe/88/responsable/1`, seule la liste est dispo. Parlant des entités, par essence de la relation `N-N`, il ne peut y avoir d'entité représentante. Puisque pour l'instant, l'application a été construite appuyée sur les entités, j'ai pris le parti de brancher le composant `groupe/responsable` sur l'entité `utilisateur`. Ce n'est pas idéal, mais il serait stupide de faire de profondes refacto à chaque fois qu'un nouvel événement arrive ; il vaut mieux patienter, faire remonter les cas et le besoin, et ainsi prendre une décision la plus documentée possible. C'est ce que je compte faire.

J'en ai profité pour faire une petite refacto, en supprimant les `foreach` pour une vision plus « programmation fonctionnelle » :yum: 

## Le test
Comme nous l'avions évoqué, l'API est presqu'exclusivement en lecture seule, aussi il n'y a que l'ordre `GET`, sur la route énoncée plus haut. Gare à la gestion des droits !