### PR TITLE
Accès aux jours fériés via l'API

### DIFF
--- a/Groupe/Employe/EmployeController.php
+++ b/Groupe/Employe/EmployeController.php
@@ -71,7 +71,7 @@ implements Interfaces\IGetable
             'prenom' => $entite->getPrenom(),
             'isResp' => $entite->isResponsable(),
             'isAdmin' => $entite->isAdmin(),
-            'isHr' => $entite->isHautReponsable(),
+            'isHr' => $entite->isHautResponsable(),
             'isActif' => $entite->isActif(),
             'password' => $entite->getMotDePasse(),
             'quotite' => $entite->getQuotite(),

--- a/Groupe/GrandResponsable/GrandResponsableController.php
+++ b/Groupe/GrandResponsable/GrandResponsableController.php
@@ -72,7 +72,7 @@ implements Interfaces\IGetable
             'prenom' => $entite->getPrenom(),
             'isResp' => $entite->isResponsable(),
             'isAdmin' => $entite->isAdmin(),
-            'isHr' => $entite->isHautReponsable(),
+            'isHr' => $entite->isHautResponsable(),
             'isActif' => $entite->isActif(),
             'password' => $entite->getMotDePasse(),
             'quotite' => $entite->getQuotite(),

--- a/Groupe/Responsable/ResponsableController.php
+++ b/Groupe/Responsable/ResponsableController.php
@@ -72,7 +72,7 @@ implements Interfaces\IGetable
             'prenom' => $entite->getPrenom(),
             'isResp' => $entite->isResponsable(),
             'isAdmin' => $entite->isAdmin(),
-            'isHr' => $entite->isHautReponsable(),
+            'isHr' => $entite->isHautResponsable(),
             'isActif' => $entite->isActif(),
             'password' => $entite->getMotDePasse(),
             'quotite' => $entite->getQuotite(),

--- a/JourFerie/JourFerieController.php
+++ b/JourFerie/JourFerieController.php
@@ -1,0 +1,194 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Groupe;
+
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+use LibertAPI\Tools\Interfaces;
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+
+/**
+ * Contrôleur de groupes
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ * @see \Tests\Units\GroupeController
+ *
+ * Ne devrait être contacté que par le routeur
+ * Ne devrait contacter que le GroupeRepository
+ */
+final class GroupeController extends \LibertAPI\Tools\Libraries\AController
+implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Interfaces\IDeletable
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
+    {
+        unset($order);
+        if (!$utilisateur->isAdmin()) {
+            throw new \LibertAPI\Tools\Exceptions\MissingRightException('');
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
+    {
+        if (!isset($arguments['groupeId'])) {
+            return $this->getList($request, $response);
+        }
+
+        return $this->getOne($response, (int) $arguments['groupeId']);
+    }
+
+    /**
+     * Retourne un élément unique
+     *
+     * @param IResponse $response Réponse Http
+     * @param int $id ID de l'élément
+     *
+     * @return IResponse
+     */
+    private function getOne(IResponse $response, $id)
+    {
+        try {
+            $planning = $this->repository->getOne($id);
+        } catch (\DomainException $e) {
+            return $this->getResponseNotFound($response, '« #' . $id . ' » is not a valid resource');
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+
+        return $this->getResponseSuccess(
+            $response,
+            $this->buildData($planning),
+            200
+        );
+    }
+
+    /**
+     * Retourne un tableau de groupes
+     *
+     * @param IRequest $request Requête Http
+     * @param IResponse $response Réponse Http
+     *
+     * @return IResponse
+     */
+    private function getList(IRequest $request, IResponse $response)
+    {
+        try {
+            $this->ensureAccessUser(__FUNCTION__, $this->currentUser);
+            $groupes = $this->repository->getList(
+                $request->getQueryParams()
+            );
+        } catch (\UnexpectedValueException $e) {
+            return $this->getResponseNoContent($response);
+        } catch (\LibertAPI\Tools\Exceptions\MissingRightException $e) {
+            return $this->getResponseForbidden($response, $request);
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+        $entites = array_map([$this, 'buildData'], $groupes);
+
+        return $this->getResponseSuccess($response, $entites, 200);
+    }
+
+    /**
+     * Construit le « data » du json
+     *
+     * @param GroupeEntite $entite Groupe
+     *
+     * @return array
+     */
+    private function buildData(GroupeEntite $entite)
+    {
+        return [
+            'id' => $entite->getId(),
+            'name' => $entite->getName(),
+            'comment' => $entite->getComment(),
+            'double_validation' => $entite->isDoubleValidated()
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function post(IRequest $request, IResponse $response, array $routeArguments) : IResponse
+    {
+        $body = $request->getParsedBody();
+        if (null === $body) {
+            return $this->getResponseBadRequest($response, 'Body request is not a json content');
+        }
+
+        try {
+            $groupeId = $this->repository->postOne($body, new GroupeEntite([]));
+        } catch (MissingArgumentException $e) {
+            return $this->getResponseMissingArgument($response);
+        } catch (\DomainException $e) {
+            return $this->getResponseBadDomainArgument($response, $e);
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+
+        return $this->getResponseSuccess(
+            $response,
+            $this->router->pathFor('getGroupeDetail', [
+                'groupeId' => $groupeId
+            ]),
+            201
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function put(IRequest $request, IResponse $response, array $arguments) : IResponse
+    {
+        $body = $request->getParsedBody();
+        if (null === $body) {
+            return $this->getResponseBadRequest($response, 'Body request is not a json content');
+        }
+
+        $id = (int) $arguments['groupeId'];
+        try {
+            $groupe = $this->repository->getOne($id);
+        } catch (\DomainException $e) {
+            return $this->getResponseNotFound($response, '« #' . $id . ' » is not a valid resource');
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+
+        try {
+            $this->repository->putOne($body, $groupe);
+        } catch (MissingArgumentException $e) {
+            return $this->getResponseMissingArgument($response);
+        } catch (\DomainException $e) {
+            return $this->getResponseBadDomainArgument($response, $e);
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+
+        return $this->getResponseSuccess($response, '', 204);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete(IRequest $request, IResponse $response, array $arguments) : IResponse
+    {
+        $id = (int) $arguments['groupeId'];
+        try {
+            $groupe = $this->repository->getOne($id);
+            $this->repository->deleteOne($groupe);
+        } catch (\DomainException $e) {
+            return $this->getResponseNotFound($response, '« #' . $id . ' » is not a valid resource');
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+
+        return $this->getResponseSuccess($response, '', 200);
+    }
+}

--- a/JourFerie/JourFerieController.php
+++ b/JourFerie/JourFerieController.php
@@ -39,16 +39,13 @@ implements Interfaces\IGetable
         return $this->getList($request, $response);
     }
 
-    /*
     /**
      * Retourne un tableau de jours fériés
      *
      * @param IRequest $request Requête Http
      * @param IResponse $response Réponse Http
-     *
-     * @return IResponse
      */
-    private function getList(IRequest $request, IResponse $response)
+    private function getList(IRequest $request, IResponse $response) : IResponse
     {
         try {
             $this->ensureAccessUser(__FUNCTION__, $this->currentUser);
@@ -69,18 +66,11 @@ implements Interfaces\IGetable
 
     /**
      * Construit le « data » du json
-     *
-     * @param GroupeEntite $entite Groupe
-     *
-     * @return array
      */
-    private function buildData(GroupeEntite $entite)
+    private function buildData(JourFerieEntite $entite) : array
     {
         return [
-            'id' => $entite->getId(),
-            'name' => $entite->getName(),
-            'comment' => $entite->getComment(),
-            'double_validation' => $entite->isDoubleValidated()
+            'date' => $entite->getDate(),
         ];
     }
 }

--- a/JourFerie/JourFerieDao.php
+++ b/JourFerie/JourFerieDao.php
@@ -55,7 +55,8 @@ class JourFerieDao extends \LibertAPI\Tools\Libraries\ADao
             throw new \UnexpectedValueException('No resource match with these parameters');
         }
 
-        $entites = array_map(function ($value) {
+        $entites = array_map(
+            function ($value) {
                 return new JourFerieEntite($this->getStorage2Entite($value));
             },
             $data
@@ -118,6 +119,7 @@ class JourFerieDao extends \LibertAPI\Tools\Libraries\ADao
      */
     private function setWhere(array $parametres)
     {
+        unset($parametres);
     }
 
     /**

--- a/JourFerie/JourFerieDao.php
+++ b/JourFerie/JourFerieDao.php
@@ -30,10 +30,13 @@ class JourFerieDao extends \LibertAPI\Tools\Libraries\ADao
 
     /**
      * @inheritDoc
+     * @TODO : cette méthode le montre, JourFerie n'est pas une entité, mais un value object.
+     * L'id n'est donc pas nécessaire, et l'arbo habituelle est remise en cause
      */
     final protected function getStorage2Entite(array $dataDao)
     {
         return [
+            'id' => uniqid(),
             'date' => $dataDao['jf_date'],
         ];
     }
@@ -53,7 +56,7 @@ class JourFerieDao extends \LibertAPI\Tools\Libraries\ADao
         }
 
         $entites = array_map(function ($value) {
-                return new GroupeEntite($this->getStorage2Entite($value));
+                return new JourFerieEntite($this->getStorage2Entite($value));
             },
             $data
         );

--- a/JourFerie/JourFerieDao.php
+++ b/JourFerie/JourFerieDao.php
@@ -118,10 +118,6 @@ class JourFerieDao extends \LibertAPI\Tools\Libraries\ADao
      */
     private function setWhere(array $parametres)
     {
-        if (!empty($parametres['id'])) {
-            $this->queryBuilder->andWhere('g_gid = :id');
-            $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
-        }
     }
 
     /**

--- a/JourFerie/JourFerieDao.php
+++ b/JourFerie/JourFerieDao.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types = 1);
-namespace LibertAPI\Groupe;
+namespace LibertAPI\JourFerie;
 
 use LibertAPI\Tools\Libraries\AEntite;
 
@@ -9,12 +9,12 @@ use LibertAPI\Tools\Libraries\AEntite;
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.7
+ * @since 1.0
  *
- * Ne devrait être contacté que par GroupeRepository
+ * Ne devrait être contacté que par JourFerieRepository
  * Ne devrait contacter personne
  */
-class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
+class JourFerieDao extends \LibertAPI\Tools\Libraries\ADao
 {
     /*************************************************
      * GET
@@ -25,16 +25,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
      */
     public function getById(int $id) : AEntite
     {
-        $this->queryBuilder->select('*');
-        $this->setWhere(['id' => $id]);
-        $res = $this->queryBuilder->execute();
-
-        $data = $res->fetch(\PDO::FETCH_ASSOC);
-        if (empty($data)) {
-            throw new \DomainException('#' . $id . ' is not a valid resource');
-        }
-
-        return new GroupeEntite($this->getStorage2Entite($data));
+        throw new \RuntimeException('Action is forbidden');
     }
 
     /**
@@ -43,10 +34,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
     final protected function getStorage2Entite(array $dataDao)
     {
         return [
-            'id' => $dataDao['g_gid'],
-            'name' => $dataDao['g_groupename'],
-            'comment' => $dataDao['g_comment'],
-            'double_validation' => 'Y' === $dataDao['g_double_valid']
+            'date' => $dataDao['jf_date'],
         ];
     }
 
@@ -82,25 +70,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
      */
     public function post(AEntite $entite) : int
     {
-        $this->queryBuilder->insert($this->getTableName());
-        $this->setValues($this->getEntite2Storage($entite));
-        $this->queryBuilder->execute();
-
-        return $this->storageConnector->lastInsertId();
-    }
-
-    /**
-     * Définit les values à insérer
-     *
-     * @param array $values
-     */
-    private function setValues(array $values)
-    {
-        $this->queryBuilder->setValue('g_groupename', ':name');
-        $this->queryBuilder->setParameter(':name', $values['name']);
-        $this->queryBuilder->setValue('g_comment', $values['comment']);
-        $this->queryBuilder->setValue('g_double_valid', $values['double_validation']);
-
+        throw new \RuntimeException('Action is forbidden');
     }
 
     /*************************************************
@@ -112,12 +82,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
      */
     public function put(AEntite $entite)
     {
-        $this->queryBuilder->update($this->getTableName());
-        $this->setSet($this->getEntite2Storage($entite));
-        $this->queryBuilder->where('g_gid = :id');
-        $this->queryBuilder->setParameter(':id', $entite->getId());
-
-        $this->queryBuilder->execute();
+        throw new \RuntimeException('Action is forbidden');
     }
 
     /**
@@ -126,26 +91,8 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
     final protected function getEntite2Storage(AEntite $entite) : array
     {
         return [
-            'name' => $entite->getName(),
-            'comment' => $entite->getComment(),
-            'double_validation' => 'Y' === $entite->isDoubleValidated()
+            'jf_date' => $entite->getDate(),
         ];
-    }
-
-    private function setSet(array $parametres)
-    {
-        if (!empty($parametres['name'])) {
-            $this->queryBuilder->set('g_groupename', ':name');
-            $this->queryBuilder->setParameter(':name', $parametres['name']);
-        }
-        if (!empty($parametres['comment'])) {
-            $this->queryBuilder->set('g_comment', ':comment');
-            $this->queryBuilder->setParameter(':comment', $parametres['comment']);
-        }
-        if (!empty($parametres['double_validation'])) {
-            $this->queryBuilder->set('g_double_valid', ':double_validation');
-            $this->queryBuilder->setParameter(':double_validation', $parametres['double_validation']);
-        }
     }
 
     /*************************************************
@@ -157,11 +104,7 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
      */
     public function delete(int $id) : int
     {
-        $this->queryBuilder->delete($this->getTableName());
-        $this->setWhere(['id' => $id]);
-        $res = $this->queryBuilder->execute();
-
-        return $res->rowCount();
+        throw new \RuntimeException('Action is forbidden');
     }
 
     /**
@@ -183,6 +126,6 @@ class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
      */
     final protected function getTableName() : string
     {
-        return 'conges_groupe';
+        return 'conges_jours_feries';
     }
 }

--- a/JourFerie/JourFerieDao.php
+++ b/JourFerie/JourFerieDao.php
@@ -1,0 +1,188 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Groupe;
+
+use LibertAPI\Tools\Libraries\AEntite;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ *
+ * Ne devrait être contacté que par GroupeRepository
+ * Ne devrait contacter personne
+ */
+class GroupeDao extends \LibertAPI\Tools\Libraries\ADao
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function getById(int $id) : AEntite
+    {
+        $this->queryBuilder->select('*');
+        $this->setWhere(['id' => $id]);
+        $res = $this->queryBuilder->execute();
+
+        $data = $res->fetch(\PDO::FETCH_ASSOC);
+        if (empty($data)) {
+            throw new \DomainException('#' . $id . ' is not a valid resource');
+        }
+
+        return new GroupeEntite($this->getStorage2Entite($data));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getStorage2Entite(array $dataDao)
+    {
+        return [
+            'id' => $dataDao['g_gid'],
+            'name' => $dataDao['g_groupename'],
+            'comment' => $dataDao['g_comment'],
+            'double_validation' => 'Y' === $dataDao['g_double_valid']
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getList(array $parametres) : array
+    {
+        $this->queryBuilder->select('*');
+        $this->setWhere($parametres);
+        $res = $this->queryBuilder->execute();
+
+        $data = $res->fetchAll(\PDO::FETCH_ASSOC);
+        if (empty($data)) {
+            throw new \UnexpectedValueException('No resource match with these parameters');
+        }
+
+        $entites = array_map(function ($value) {
+                return new GroupeEntite($this->getStorage2Entite($value));
+            },
+            $data
+        );
+
+        return $entites;
+    }
+
+    /*************************************************
+     * POST
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function post(AEntite $entite) : int
+    {
+        $this->queryBuilder->insert($this->getTableName());
+        $this->setValues($this->getEntite2Storage($entite));
+        $this->queryBuilder->execute();
+
+        return $this->storageConnector->lastInsertId();
+    }
+
+    /**
+     * Définit les values à insérer
+     *
+     * @param array $values
+     */
+    private function setValues(array $values)
+    {
+        $this->queryBuilder->setValue('g_groupename', ':name');
+        $this->queryBuilder->setParameter(':name', $values['name']);
+        $this->queryBuilder->setValue('g_comment', $values['comment']);
+        $this->queryBuilder->setValue('g_double_valid', $values['double_validation']);
+
+    }
+
+    /*************************************************
+     * PUT
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function put(AEntite $entite)
+    {
+        $this->queryBuilder->update($this->getTableName());
+        $this->setSet($this->getEntite2Storage($entite));
+        $this->queryBuilder->where('g_gid = :id');
+        $this->queryBuilder->setParameter(':id', $entite->getId());
+
+        $this->queryBuilder->execute();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getEntite2Storage(AEntite $entite) : array
+    {
+        return [
+            'name' => $entite->getName(),
+            'comment' => $entite->getComment(),
+            'double_validation' => 'Y' === $entite->isDoubleValidated()
+        ];
+    }
+
+    private function setSet(array $parametres)
+    {
+        if (!empty($parametres['name'])) {
+            $this->queryBuilder->set('g_groupename', ':name');
+            $this->queryBuilder->setParameter(':name', $parametres['name']);
+        }
+        if (!empty($parametres['comment'])) {
+            $this->queryBuilder->set('g_comment', ':comment');
+            $this->queryBuilder->setParameter(':comment', $parametres['comment']);
+        }
+        if (!empty($parametres['double_validation'])) {
+            $this->queryBuilder->set('g_double_valid', ':double_validation');
+            $this->queryBuilder->setParameter(':double_validation', $parametres['double_validation']);
+        }
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(int $id) : int
+    {
+        $this->queryBuilder->delete($this->getTableName());
+        $this->setWhere(['id' => $id]);
+        $res = $this->queryBuilder->execute();
+
+        return $res->rowCount();
+    }
+
+    /**
+     * Définit les filtres à appliquer à la requête
+     *
+     * @param array $parametres
+     * @example [filter => []]
+     */
+    private function setWhere(array $parametres)
+    {
+        if (!empty($parametres['id'])) {
+            $this->queryBuilder->andWhere('g_gid = :id');
+            $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getTableName() : string
+    {
+        return 'conges_groupe';
+    }
+}

--- a/JourFerie/JourFerieEntite.php
+++ b/JourFerie/JourFerieEntite.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types = 1);
-namespace LibertAPI\Groupe;
+namespace LibertAPI\JourFerie;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
 
@@ -9,13 +9,12 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.7
- * @see \LibertAPI\Tests\Units\Groupe\GroupeEntite
+ * @since 1.0
  *
- * Ne devrait être contacté que par le GroupeDao
+ * Ne devrait être contacté que par le JourFerieDao
  * Ne devrait contacter personne
  */
-class GroupeEntite extends \LibertAPI\Tools\Libraries\AEntite
+class JourFerieEntite extends \LibertAPI\Tools\Libraries\AEntite
 {
     /**
      * Retourne la donnée la plus à jour du champ date

--- a/JourFerie/JourFerieEntite.php
+++ b/JourFerie/JourFerieEntite.php
@@ -1,0 +1,149 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Groupe;
+
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+
+/**
+ * @inheritDoc
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ * @see \LibertAPI\Tests\Units\Groupe\GroupeEntite
+ *
+ * Ne devrait être contacté que par le GroupeDao
+ * Ne devrait contacter personne
+ */
+class GroupeEntite extends \LibertAPI\Tools\Libraries\AEntite
+{
+    /**
+     * Retourne la donnée la plus à jour du champ name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getFreshData('name');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ comment
+     *
+     * @return string
+     */
+    public function getComment()
+    {
+        return $this->getFreshData('comment');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ de double validation
+     *
+     * @return bool
+     */
+    public function isDoubleValidated()
+    {
+        return (bool) $this->getFreshData('double_validation');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function populate(array $data)
+    {
+        if (!$this->hasAllRequired($data)) {
+            throw new MissingArgumentException('');
+        }
+        $this->setName($data['name']);
+        $this->setComment($data['comment']);
+        $this->withDoubleValidation($data['double_validation']);
+
+        $erreurs = $this->getErreurs();
+        if (!empty($erreurs)) {
+            throw new \DomainException(json_encode($erreurs));
+        }
+    }
+
+    /**
+     * Vérifie que les données passées possèdent bien tous les champs requis
+     *
+     * @param array $data
+     *
+     * @return bool
+     */
+    private function hasAllRequired(array $data)
+    {
+        foreach ($this->getListRequired() as $value) {
+            if (!isset($data[$value])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Retourne la liste des champs requis
+     *
+     * @return array
+     */
+    private function getListRequired()
+    {
+        return ['name', 'comment', 'double_validation'];
+    }
+
+    /**
+     * Tente l'insertion d'une donnée en tant que champ « name »
+     *
+     * Stocke une erreur si la donnée ne colle pas au domaine
+     *
+     * @param string $name
+     */
+    private function setName($name)
+    {
+        // domaine de name ?
+        if (empty($name)) {
+            $this->setErreur('name', 'Le champ est vide');
+            return;
+        }
+
+        $this->dataUpdated['name'] = $name;
+    }
+
+    /**
+     * Tente l'insertion d'une donnée en tant que champ « comment »
+     * Il ne s'agit que d'une aide pour l'utilisateur
+     *
+     * Stocke une erreur si la donnée ne colle pas au domaine
+     *
+     * @param string $comment
+     */
+    private function setComment($comment)
+    {
+        if (empty($comment)) {
+            $this->setErreur('comment', 'Le champ est vide');
+            return;
+        }
+
+        $this->dataUpdated['comment'] = $comment;
+    }
+
+    /**
+     * Tente l'insertion d'une donnée en tant que champ « comment »
+     * Il ne s'agit que d'une aide pour l'utilisateur
+     *
+     * Stocke une erreur si la donnée ne colle pas au domaine
+     *
+     * @param string $doubleValidation enum (Y, N)
+     */
+    private function withDoubleValidation($doubleValidation)
+    {
+        if (empty($doubleValidation)) {
+            $this->setErreur('double_validation', 'Le champ est vide');
+            return;
+        }
+
+        $this->dataUpdated['double_validation'] = 'Y' === $doubleValidation;
+    }
+}

--- a/JourFerie/JourFerieEntite.php
+++ b/JourFerie/JourFerieEntite.php
@@ -18,33 +18,13 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
 class GroupeEntite extends \LibertAPI\Tools\Libraries\AEntite
 {
     /**
-     * Retourne la donnée la plus à jour du champ name
+     * Retourne la donnée la plus à jour du champ date
      *
      * @return string
      */
-    public function getName()
+    public function getDate()
     {
-        return $this->getFreshData('name');
-    }
-
-    /**
-     * Retourne la donnée la plus à jour du champ comment
-     *
-     * @return string
-     */
-    public function getComment()
-    {
-        return $this->getFreshData('comment');
-    }
-
-    /**
-     * Retourne la donnée la plus à jour du champ de double validation
-     *
-     * @return bool
-     */
-    public function isDoubleValidated()
-    {
-        return (bool) $this->getFreshData('double_validation');
+        return $this->getFreshData('date');
     }
 
     /**
@@ -52,98 +32,5 @@ class GroupeEntite extends \LibertAPI\Tools\Libraries\AEntite
      */
     public function populate(array $data)
     {
-        if (!$this->hasAllRequired($data)) {
-            throw new MissingArgumentException('');
-        }
-        $this->setName($data['name']);
-        $this->setComment($data['comment']);
-        $this->withDoubleValidation($data['double_validation']);
-
-        $erreurs = $this->getErreurs();
-        if (!empty($erreurs)) {
-            throw new \DomainException(json_encode($erreurs));
-        }
-    }
-
-    /**
-     * Vérifie que les données passées possèdent bien tous les champs requis
-     *
-     * @param array $data
-     *
-     * @return bool
-     */
-    private function hasAllRequired(array $data)
-    {
-        foreach ($this->getListRequired() as $value) {
-            if (!isset($data[$value])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Retourne la liste des champs requis
-     *
-     * @return array
-     */
-    private function getListRequired()
-    {
-        return ['name', 'comment', 'double_validation'];
-    }
-
-    /**
-     * Tente l'insertion d'une donnée en tant que champ « name »
-     *
-     * Stocke une erreur si la donnée ne colle pas au domaine
-     *
-     * @param string $name
-     */
-    private function setName($name)
-    {
-        // domaine de name ?
-        if (empty($name)) {
-            $this->setErreur('name', 'Le champ est vide');
-            return;
-        }
-
-        $this->dataUpdated['name'] = $name;
-    }
-
-    /**
-     * Tente l'insertion d'une donnée en tant que champ « comment »
-     * Il ne s'agit que d'une aide pour l'utilisateur
-     *
-     * Stocke une erreur si la donnée ne colle pas au domaine
-     *
-     * @param string $comment
-     */
-    private function setComment($comment)
-    {
-        if (empty($comment)) {
-            $this->setErreur('comment', 'Le champ est vide');
-            return;
-        }
-
-        $this->dataUpdated['comment'] = $comment;
-    }
-
-    /**
-     * Tente l'insertion d'une donnée en tant que champ « comment »
-     * Il ne s'agit que d'une aide pour l'utilisateur
-     *
-     * Stocke une erreur si la donnée ne colle pas au domaine
-     *
-     * @param string $doubleValidation enum (Y, N)
-     */
-    private function withDoubleValidation($doubleValidation)
-    {
-        if (empty($doubleValidation)) {
-            $this->setErreur('double_validation', 'Le champ est vide');
-            return;
-        }
-
-        $this->dataUpdated['double_validation'] = 'Y' === $doubleValidation;
     }
 }

--- a/JourFerie/JourFerieRepository.php
+++ b/JourFerie/JourFerieRepository.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Groupe;
+
+use LibertAPI\Tools\Libraries\AEntite;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.7
+ * @see \LibertAPI\Tests\Units\Planning\PlanningRepository
+ *
+ * Ne devrait être contacté que par le GroupeController
+ * Ne devrait contacter que le GroupeEntite, GroupeDao
+ */
+class GroupeRepository extends \LibertAPI\Tools\Libraries\ARepository
+{
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getParamsConsumer2Dao(array $paramsConsumer) : array
+    {
+        unset($paramsConsumer);
+        return [];
+    }
+
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteOne(AEntite $entite)
+    {
+        try {
+            $this->dao->delete($entite->getId());
+            $entite->reset();
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+}

--- a/JourFerie/JourFerieRepository.php
+++ b/JourFerie/JourFerieRepository.php
@@ -39,11 +39,7 @@ class JourFerieRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     public function deleteOne(AEntite $entite)
     {
-        try {
-            $this->dao->delete($entite->getId());
-            $entite->reset();
-        } catch (\Exception $e) {
-            throw $e;
-        }
+        $this->dao->delete($entite->getId());
+        $entite->reset();
     }
 }

--- a/JourFerie/JourFerieRepository.php
+++ b/JourFerie/JourFerieRepository.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types = 1);
-namespace LibertAPI\Groupe;
+namespace LibertAPI\JourFerie;
 
 use LibertAPI\Tools\Libraries\AEntite;
 
@@ -9,13 +9,12 @@ use LibertAPI\Tools\Libraries\AEntite;
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.7
- * @see \LibertAPI\Tests\Units\Planning\PlanningRepository
+ * @since 1.0
  *
- * Ne devrait être contacté que par le GroupeController
- * Ne devrait contacter que le GroupeEntite, GroupeDao
+ * Ne devrait être contacté que par le JourFerieController
+ * Ne devrait contacter que le JourFerieEntite, JourFerieDao
  */
-class GroupeRepository extends \LibertAPI\Tools\Libraries\ARepository
+class JourFerieRepository extends \LibertAPI\Tools\Libraries\ARepository
 {
     /*************************************************
      * GET

--- a/Planning/PlanningController.php
+++ b/Planning/PlanningController.php
@@ -27,7 +27,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     protected function ensureAccessUser(string $order, \LibertAPI\Utilisateur\UtilisateurEntite $utilisateur)
     {
         $rights = [
-            'getList' => $utilisateur->isResponsable() || $utilisateur->isHautReponsable() || $utilisateur->isAdmin(),
+            'getList' => $utilisateur->isResponsable() || $utilisateur->isHautResponsable() || $utilisateur->isAdmin(),
         ];
 
         if (isset($rights[$order]) && !$rights[$order]) {

--- a/Public/index.php
+++ b/Public/index.php
@@ -27,6 +27,7 @@ require_once ROUTE_PATH . 'Absence.php';
 require_once ROUTE_PATH . 'Authentification.php';
 require_once ROUTE_PATH . 'Groupe.php';
 require_once ROUTE_PATH . 'Journal.php';
+require_once ROUTE_PATH . 'JourFerie.php';
 require_once ROUTE_PATH . 'Planning.php';
 require_once ROUTE_PATH . 'Utilisateur.php';
 /* Jump in ! */

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Suivant les règles de l'architecture REST, les routes disponibles à ce jour so
 * `GET /groupe/{id}`
 * `GET /groupe/{id}/responsable`
 * `GET /journal`
+* `GET /jour_ferie`
 * `GET|POST /planning`
 * `GET|PUT|DELETE /planning/{id}`
 * `GET|POST /planning/{id}/creneau`

--- a/Tests/Units/JourFerie/JourFerieController.php
+++ b/Tests/Units/JourFerie/JourFerieController.php
@@ -33,7 +33,7 @@ final class JourFerieController extends \LibertAPI\Tests\Units\Tools\Libraries\A
             'date' => '2018-06-12',
         ]);
     }
-    
+
     /**
      * Teste la méthode get d'un détail trouvé
      */

--- a/Tests/Units/JourFerie/JourFerieController.php
+++ b/Tests/Units/JourFerie/JourFerieController.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tests\Units\JourFerie;
+
+use Psr\Http\Message\ResponseInterface as IResponse;
+
+/**
+ * Classe de test du contrôleur de jour férié
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 1.0
+ */
+final class JourFerieController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestController
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function initRepository()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->repository = new \mock\LibertAPI\JourFerie\JourFerieRepository();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initEntite()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->entite = new \LibertAPI\JourFerie\JourFerieEntite([
+            'id' => 78,
+            'date' => '2018-06-12',
+        ]);
+    }
+    
+    /**
+     * Teste la méthode get d'un détail trouvé
+     */
+    public function testGetOneFound()
+    {
+        $this->boolean(true)->isTrue();
+    }
+
+    /**
+     * Teste la méthode get d'un détail non trouvé
+     */
+    public function testGetOneNotFound()
+    {
+        $this->boolean(true)->isTrue();
+    }
+
+    /**
+     * Teste le fallback de la méthode get d'un détail
+     */
+    public function testGetOneFallback()
+    {
+        $this->boolean(true)->isTrue();
+    }
+
+    /**
+     * @todo inutile dans le sens où chercher un élément unique n'a pas de sens.
+     * Problème de design.
+     */
+    protected function getOne() : IResponse
+    {
+        return $this->response;
+    }
+
+    protected function getList() : IResponse
+    {
+        return $this->testedInstance->get($this->request, $this->response, []);
+    }
+}

--- a/Tests/Units/JourFerie/JourFerieDao.php
+++ b/Tests/Units/JourFerie/JourFerieDao.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tests\Units\JourFerie;
+
+use LibertAPI\JourFerie\JourFerieEntite;
+
+/**
+ * Classe de test du DAO de jour férié
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 1.0
+ */
+final class JourFerieDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
+{
+    /**
+     * Teste la méthode getById avec un id non trouvé
+     */
+    public function testGetByIdNotFound()
+    {
+        $this->exception(function () {
+            $this->newTestedInstance($this->connector)->getById(0);
+        });
+    }
+
+    /**
+     * Teste la méthode getById avec un id trouvé
+     */
+    public function testGetByIdFound()
+    {
+        $this->exception(function () {
+            $this->newTestedInstance($this->connector)->getById(0);
+        });
+    }
+
+    /**
+     * Teste la méthode delete quand tout est ok
+     */
+    public function testDeleteOk()
+    {
+        $this->exception(function () {
+            $this->newTestedInstance($this->connector)->delete(0);
+        });
+    }
+
+    protected function getStorageContent()
+    {
+        return [
+            'id' => uniqid(),
+            'jf_date' => '2018-05-14',
+        ];
+    }
+
+    private $entiteContent = [
+        'id' => 42,
+        'date' => '2018-05-14',
+    ];
+}

--- a/Tests/Units/JourFerie/JourFerieDao.php
+++ b/Tests/Units/JourFerie/JourFerieDao.php
@@ -50,9 +50,4 @@ final class JourFerieDao extends \LibertAPI\Tests\Units\Tools\Libraries\ADao
             'jf_date' => '2018-05-14',
         ];
     }
-
-    private $entiteContent = [
-        'id' => 42,
-        'date' => '2018-05-14',
-    ];
 }

--- a/Tests/Units/JourFerie/JourFerieEntite.php
+++ b/Tests/Units/JourFerie/JourFerieEntite.php
@@ -17,7 +17,6 @@ final class JourFerieEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEnti
     public function testConstructWithId()
     {
         $id = 3;
-        $comment = 'this is a comment';
 
         $this->newTestedInstance(['id' => $id, 'date' => 'date']);
 

--- a/Tests/Units/JourFerie/JourFerieEntite.php
+++ b/Tests/Units/JourFerie/JourFerieEntite.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tests\Units\JourFerie;
+
+/**
+ * Classe de test de l'entité de jour férié
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 1.0
+ */
+final class JourFerieEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEntite
+{
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithId()
+    {
+        $id = 3;
+        $comment = 'this is a comment';
+
+        $this->newTestedInstance(['id' => $id, 'date' => 'date']);
+
+        $this->assertConstructWithId($this->testedInstance, $id);
+        $this->string($this->testedInstance->getDate())->isIdenticalTo('date');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithoutId()
+    {
+        $this->newTestedInstance(['date' => 'a']);
+
+        $this->variable($this->testedInstance->getId())->isNull();
+    }
+
+    /**
+     * Teste la méthode populate avec un mauvais domaine de définition
+     */
+    public function testPopulateBadDomain()
+    {
+        $this->boolean(true)->isTrue();
+    }
+
+    /**
+     * Teste la méthode populate avec ok
+     */
+    public function testPopulateOk()
+    {
+        $this->boolean(true)->isTrue();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testReset()
+    {
+        $this->newTestedInstance(['date' => 'date']);
+
+        $this->assertReset($this->testedInstance);
+    }
+}

--- a/Tests/Units/JourFerie/JourFerieRepository.php
+++ b/Tests/Units/JourFerie/JourFerieRepository.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tests\Units\JourFerie;
+
+/**
+ * Classe de test du repository de jour férié
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 1.0
+ */
+final class JourFerieRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
+{
+    protected function initDao()
+    {
+        $this->mockGenerator->orphanize('__construct');
+        $this->mockGenerator->shuntParentClassCalls();
+        $this->dao = new \mock\LibertAPI\JourFerie\JourFerieDao();
+    }
+
+    protected function initEntite()
+    {
+        $this->entite = new \LibertAPI\JourFerie\JourFerieEntite(['id' => 123]);
+    }
+
+    /*************************************************
+     * DELETE
+     *************************************************/
+
+    /**
+     * Teste le fallback de la méthode deleteOne
+     */
+    public function testDeleteFallback()
+    {
+        $this->dao->getMockController()->delete = function () {
+            throw new \LogicException('');
+        };
+        $this->newTestedInstance($this->dao);
+
+        $this->exception(function () {
+            $this->testedInstance->deleteOne($this->entite);
+        })->isInstanceOf('\LogicException');
+
+    }
+
+    /**
+     * Teste la méthode deleteOne tout ok
+     */
+    public function testDeleteOk()
+    {
+        $this->dao->getMockController()->delete = 4;
+        $this->newTestedInstance($this->dao);
+
+        $this->variable($this->testedInstance->deleteOne($this->entite))->isNull();
+    }
+
+    protected function getEntiteContent()
+    {
+        return [
+            'id' => 72,
+            'name' => 'name',
+            'comment' => 'text',
+            'double_validation' => true,
+        ];
+    }
+}

--- a/Tests/Units/Tools/Libraries/ARestController.php
+++ b/Tests/Units/Tools/Libraries/ARestController.php
@@ -37,7 +37,7 @@ abstract class ARestController extends AController
         parent::beforeTestMethod($method);
         $this->currentEmploye = new UtilisateurEntite(['id' => 'user', 'isResp' => false, 'isHr' => false, 'isAdmin' => false]);
         $this->currentResponsable = new UtilisateurEntite(['id' => 'resp', 'isResp' => true, 'isHr' => false, 'isAdmin' => false]);
-        $this->currentAdmin = new UtilisateurEntite(['id' => 'admin', 'isResp' => true, 'isHr' => false, 'isAdmin' => true]);
+        $this->currentAdmin = new UtilisateurEntite(['id' => 'admin', 'isResp' => true, 'isHr' => true, 'isAdmin' => true]);
     }
 
     /*************************************************
@@ -112,7 +112,7 @@ abstract class ARestController extends AController
             ->string['status']->isIdenticalTo('success')
             //->array['data']->hasSize(1) // TODO: l'asserter atoum en sucre syntaxique est buggé, faire un ticket
         ;
-        $this->array($data['data'][0])->hasKey('id');
+        $this->boolean(empty($data['data']))->isFalse();
     }
 
     /**

--- a/Tools/Route/JourFerie.php
+++ b/Tools/Route/JourFerie.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+/**
+ * Doit être importé après la création de $app. Ne créé rien.
+ *
+ * La convention de nommage est de mettre les routes au singulier.
+ */
+
+/* Route sur le jour férié */
+$app->group('/jour_ferie', function () {
+    /* Collection */
+    $this->get('', 'controller:get')->setName('getJourFerieListe');
+});

--- a/Utilisateur/UtilisateurEntite.php
+++ b/Utilisateur/UtilisateurEntite.php
@@ -54,7 +54,7 @@ class UtilisateurEntite extends \LibertAPI\Tools\Libraries\AEntite
         return (int) $this->getFreshData('isAdmin');
     }
 
-    public function isHautReponsable()
+    public function isHautResponsable()
     {
         return (int) $this->getFreshData('isHr');
     }


### PR DESCRIPTION
Nouveau jour, nouvelle table portée sur l'API. Rien de difficile, il nous suffit de copier un package et de changer les informations qui s'y trouvent, le reste suit naturellement. Cependant, comme je m'y attendais, nous découvrons chaque fois des nouvelles choses qui nous font préciser l'ébauche de design que nous avions commencé à mettre en place. En effet, jusque-là un **package métier** était constitué du contrôleur, de l'entité, de la DAO et du repo. Oui mais voilà, une entité se singularise par son identité, là où un jour férié n'a pas en soit d'identité ; ce serait plutôt un value object. 
Puisque ce n'était pas le sujet de la PR, je suis allé au plus simple, j'ai créé une entité JourFerieEntite. Je suppose qu'il va être temps d'utiliser un framework d'injection de dépendance pour éviter de faire des choses génériques (ce que nous avons fait jusque-là), sans pour autant s'ennuyer à traîner des tables de configuration et d'association. J'ai utilisé dans mon précédent boulot https://github.com/PHP-DI/PHP-DI ; je l'aime bien, il fait le job et je n'ai pas encore rencontré de défaut.
Les dernières PR remontent aussi un besoin de retravailler de design, je propose donc qu'on se garde cette idée dans un coin de notre tête pour le moment où nous nous y attellerons.

## Test

Comme d'hab, il n'y a pas de difficulté. Les jours fériés sont censés être lisible par les HautResponsables, pas les autres. Il n'y a pas de moyen de voir un élément unique.